### PR TITLE
[azure][lfo] Bug fix when setting monitored subscriptions

### DIFF
--- a/azure/logging_install/src/azure_logging_install/resource_setup.py
+++ b/azure/logging_install/src/azure_logging_install/resource_setup.py
@@ -218,7 +218,7 @@ def create_function_app(config: Configuration, name: str):
     # Task-specific settings
     if name == config.resources_task_name:
         specific_settings = {
-            "MONITORED_SUBSCRIPTIONS": ",".join(config.monitored_subscriptions),
+            "MONITORED_SUBSCRIPTIONS": json.dumps(config.monitored_subscriptions),
             "RESOURCE_TAG_FILTERS": config.resource_tag_filters,
         }
     elif name == config.diagnostic_settings_task_name:


### PR DESCRIPTION
### Overview
Ensure we write the monitored subscriptions as a JSON array instead of a comma-separated string. 

### Testing
- Unit tests passing
- Manual tests passing