### PR TITLE
Remove dist/ from gitignore

### DIFF
--- a/azure/.gitignore
+++ b/azure/.gitignore
@@ -23,5 +23,4 @@ __pycache__/
 *.egg-info/
 
 # Build artifacts
-dist/
 build/


### PR DESCRIPTION
Since we will be pushing these files so that they can be referenced via cURL