### PR TITLE
[AZINTS-3739] Move LFO templates (and TF) to integrations-management

### DIFF
--- a/azure/logging_install/bicep/README.md
+++ b/azure/logging_install/bicep/README.md
@@ -1,0 +1,21 @@
+# Arm Template
+
+(this assumes your current directory is the root of the repo)
+
+## Setup:
+
+```bash
+# ensure the az cli is installed
+brew install azure-cli
+# install the bicep cli
+az bicep install
+```
+
+## Development:
+
+To work with the bicep files, you can just make your changes and then run the
+deploy personal environment script with --force-arm-deploy to deploy the changes:
+
+```bash
+./scripts/deploy_personal_env.py --force-arm-deploy
+```

--- a/azure/logging_install/bicep/azuredeploy.bicep
+++ b/azure/logging_install/bicep/azuredeploy.bicep
@@ -1,0 +1,127 @@
+targetScope = 'managementGroup'
+
+param monitoredSubscriptions string
+
+param controlPlaneLocation string
+param controlPlaneSubscriptionId string
+param controlPlaneResourceGroupName string
+
+@secure()
+@description('Datadog API Key')
+param datadogApiKey string
+@description('Datadog Site')
+param datadogSite string
+@description('Comma separated list of tags to filter resources by')
+param resourceTagFilters string = ''
+@description('YAML formatted list of PII Scrubber Rules')
+param piiScrubberRules string = ''
+param datadogTelemetry bool = false
+param logLevel string = 'INFO'
+
+param imageRegistry string = 'datadoghq.azurecr.io'
+#disable-next-line no-hardcoded-env-urls
+param storageAccountUrl string = 'https://ddazurelfo.blob.core.windows.net'
+
+func subUuid(uuid string) string => toLower(substring(uuid, 24, 12))
+
+// sub-uuid for the control plane is based on the identifiers below.
+// This is to be consistent if there are multiple deploys, while still making a unique id.
+// - the management group
+// - control plane subscription id
+// - control plane resource group name
+// - control plane region
+var controlPlaneId = subUuid(guid(
+  managementGroup().id,
+  controlPlaneSubscriptionId,
+  controlPlaneResourceGroupName,
+  controlPlaneLocation
+))
+
+module controlPlaneResourceGroup './control_plane_resource_group.bicep' = {
+  name: 'controlPlaneResourceGroup-${controlPlaneId}'
+  scope: subscription(controlPlaneSubscriptionId)
+  params: {
+    controlPlaneResourceGroup: controlPlaneResourceGroupName
+    controlPlaneLocation: controlPlaneLocation
+  }
+}
+
+module validateConfig './validate_config.bicep' = {
+  name: 'validateConfig-${controlPlaneId}'
+  scope: resourceGroup(controlPlaneSubscriptionId, controlPlaneResourceGroupName)
+  params: {
+    datadogApiKey: datadogApiKey
+    datadogSite: datadogSite
+    piiScrubberRules: piiScrubberRules
+  }
+  dependsOn: [
+    controlPlaneResourceGroup
+  ]
+}
+
+module controlPlane './control_plane.bicep' = {
+  name: 'controlPlane-${controlPlaneId}'
+  scope: resourceGroup(controlPlaneSubscriptionId, controlPlaneResourceGroupName)
+  params: {
+    controlPlaneId: controlPlaneId
+    controlPlaneLocation: controlPlaneLocation
+    controlPlaneResourceGroupName: controlPlaneResourceGroupName
+    controlPlaneSubscriptionId: controlPlaneSubscriptionId
+    monitoredSubscriptions: monitoredSubscriptions
+    datadogApiKey: datadogApiKey
+    datadogSite: datadogSite
+    datadogTelemetry: datadogTelemetry
+    resourceTagFilters: resourceTagFilters
+    piiScrubberRules: piiScrubberRules
+    imageRegistry: imageRegistry
+    storageAccountUrl: storageAccountUrl
+    logLevel: logLevel
+  }
+  dependsOn: [
+    controlPlaneResourceGroup
+    validateConfig
+  ]
+}
+
+var resourceTaskPrincipalId = controlPlane.outputs.resourceTaskPrincipalId
+var diagnosticSettingsTaskPrincipalId = controlPlane.outputs.diagnosticSettingsTaskPrincipalId
+var scalingTaskPrincipalId = controlPlane.outputs.scalingTaskPrincipalId
+
+// create the subscription level permissions, as well as the resource group for forwarders and the permissions on that resource group
+module subscriptionPermissions './subscription_permissions.bicep' = [
+  for subscriptionId in json(monitoredSubscriptions): {
+    name: 'subscriptionPermissions-${subUuid(subscriptionId)}-${controlPlaneId}'
+    scope: subscription(subscriptionId)
+    params: {
+      resourceGroupName: controlPlaneResourceGroupName
+      location: controlPlaneLocation
+      controlPlaneId: controlPlaneId
+      resourceTaskPrincipalId: resourceTaskPrincipalId
+      diagnosticSettingsTaskPrincipalId: diagnosticSettingsTaskPrincipalId
+      scalingTaskPrincipalId: scalingTaskPrincipalId
+      initialRunIdentityPrincipalId: controlPlane.outputs.initialRunIdentityPrincipalId
+    }
+  }
+]
+
+module initialRun './initial_run.bicep' = {
+  name: 'initialRun-${controlPlaneId}'
+  scope: resourceGroup(controlPlaneSubscriptionId, controlPlaneResourceGroupName)
+  params: {
+    controlPlaneId: controlPlaneId
+    initialRunIdentity: controlPlane.outputs.initialRunIdentityId
+    storageAccountName: controlPlane.outputs.storageAccountName
+    datadogApiKey: datadogApiKey
+    datadogSite: datadogSite
+    datadogTelemetry: datadogTelemetry
+    logLevel: logLevel
+    monitoredSubscriptions: monitoredSubscriptions
+    piiScrubberRules: piiScrubberRules
+    resourceTagFilters: resourceTagFilters
+    forwarderImage: '${imageRegistry}/forwarder:latest'
+    storageAccountUrl: storageAccountUrl
+  }
+  dependsOn: [
+    subscriptionPermissions
+  ]
+}

--- a/azure/logging_install/bicep/control_plane.bicep
+++ b/azure/logging_install/bicep/control_plane.bicep
@@ -1,0 +1,282 @@
+targetScope = 'resourceGroup'
+
+param controlPlaneId string
+
+param controlPlaneLocation string
+param controlPlaneSubscriptionId string
+param controlPlaneResourceGroupName string
+param monitoredSubscriptions string
+
+param imageRegistry string
+param storageAccountUrl string
+
+@secure()
+param datadogApiKey string
+param datadogSite string
+param piiScrubberRules string
+param resourceTagFilters string
+param datadogTelemetry bool
+param logLevel string
+
+var deployerTaskImage = '${imageRegistry}/deployer:latest'
+var forwarderImage = '${imageRegistry}/forwarder:latest'
+
+// Settings
+var STORAGE_CONNECTION_SETTING = 'AzureWebJobsStorage'
+var DD_SITE_SETTING = 'DD_SITE'
+var DD_API_KEY_SETTING = 'DD_API_KEY'
+var DD_TELEMETRY_SETTING = 'DD_TELEMETRY'
+var FORWARDER_IMAGE_SETTING = 'FORWARDER_IMAGE'
+var SUBSCRIPTION_ID_SETTING = 'SUBSCRIPTION_ID'
+var RESOURCE_GROUP_SETTING = 'RESOURCE_GROUP'
+var CONTROL_PLANE_REGION_SETTING = 'CONTROL_PLANE_REGION'
+var CONTROL_PLANE_ID_SETTING = 'CONTROL_PLANE_ID'
+var MONITORED_SUBSCRIPTIONS_SETTING = 'MONITORED_SUBSCRIPTIONS'
+var RESOURCE_TAG_FILTERS_SETTING = 'RESOURCE_TAG_FILTERS'
+var PII_SCRUBBER_RULES_SETTING = 'PII_SCRUBBER_RULES'
+var STORAGE_ACCOUNT_URL_SETTING = 'STORAGE_ACCOUNT_URL'
+var LOG_LEVEL_SETTING = 'LOG_LEVEL'
+
+// Secret Names
+var DD_API_KEY_SECRET = 'dd-api-key'
+var CONNECTION_STRING_SECRET = 'connection-string'
+
+// CONTROL PLANE RESOURCES
+
+resource asp 'Microsoft.Web/serverfarms@2022-09-01' = {
+  name: 'control-plane-asp-${controlPlaneId}'
+  location: controlPlaneLocation
+  kind: 'linux'
+  properties: {
+    reserved: true
+  }
+  sku: {
+    tier: 'Dynamic'
+    name: 'Y1'
+  }
+}
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: 'lfostorage${controlPlaneId}'
+  kind: 'StorageV2'
+  location: controlPlaneLocation
+  properties: {
+    accessTier: 'Hot'
+    minimumTlsVersion: 'TLS1_2'
+  }
+  sku: { name: 'Standard_LRS' }
+}
+
+resource fileServices 'Microsoft.Storage/storageAccounts/fileServices@2023-05-01' = {
+  name: 'default'
+  parent: storageAccount
+  properties: {}
+}
+
+resource blobServices 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+  name: 'default'
+  parent: storageAccount
+  properties: {}
+}
+
+resource cacheContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-01-01' = {
+  name: 'control-plane-cache'
+  parent: blobServices
+  properties: {}
+}
+
+var storageAccountKey = listKeys(storageAccount.id, '2019-06-01').keys[0].value
+var connectionString = 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccountKey}'
+
+var commonAppSettings = [
+  { name: STORAGE_CONNECTION_SETTING, value: connectionString }
+  { name: DD_API_KEY_SETTING, value: datadogApiKey }
+  { name: DD_SITE_SETTING, value: datadogSite }
+  { name: DD_TELEMETRY_SETTING, value: datadogTelemetry ? 'true' : 'false' }
+  { name: CONTROL_PLANE_ID_SETTING, value: controlPlaneId }
+  { name: 'AzureWebJobsFeatureFlags', value: 'EnableWorkerIndexing' }
+  { name: 'FUNCTIONS_EXTENSION_VERSION', value: '~4' }
+  { name: 'FUNCTIONS_WORKER_RUNTIME', value: 'python' }
+  { name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING', value: connectionString }
+  { name: LOG_LEVEL_SETTING, value: logLevel }
+]
+
+var resourceTaskName = 'resources-task-${controlPlaneId}'
+resource resourceTask 'Microsoft.Web/sites@2022-09-01' = {
+  name: resourceTaskName
+  location: controlPlaneLocation
+  kind: 'functionapp'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: asp.id
+    siteConfig: {
+      appSettings: union(commonAppSettings, [
+        { name: 'WEBSITE_CONTENTSHARE', value: resourceTaskName }
+        { name: MONITORED_SUBSCRIPTIONS_SETTING, value: monitoredSubscriptions }
+        { name: RESOURCE_TAG_FILTERS_SETTING, value: resourceTagFilters }
+      ])
+      linuxFxVersion: 'Python|3.11'
+    }
+    publicNetworkAccess: 'Enabled'
+    httpsOnly: true
+  }
+  dependsOn: [fileServices]
+}
+var diagnosticSettingsTaskName = 'diagnostic-settings-task-${controlPlaneId}'
+resource diagnosticSettingsTask 'Microsoft.Web/sites@2022-09-01' = {
+  name: diagnosticSettingsTaskName
+  location: controlPlaneLocation
+  kind: 'functionapp'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: asp.id
+    siteConfig: {
+      appSettings: union(commonAppSettings, [
+        { name: RESOURCE_GROUP_SETTING, value: controlPlaneResourceGroupName }
+        { name: 'WEBSITE_CONTENTSHARE', value: resourceTaskName }
+      ])
+      linuxFxVersion: 'Python|3.11'
+    }
+    publicNetworkAccess: 'Enabled'
+    httpsOnly: true
+  }
+  dependsOn: [fileServices]
+}
+
+var scalingTaskName = 'scaling-task-${controlPlaneId}'
+resource scalingTask 'Microsoft.Web/sites@2022-09-01' = {
+  name: scalingTaskName
+  location: controlPlaneLocation
+  kind: 'functionapp'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: asp.id
+    siteConfig: {
+      appSettings: union(commonAppSettings, [
+        { name: RESOURCE_GROUP_SETTING, value: controlPlaneResourceGroupName }
+        { name: 'WEBSITE_CONTENTSHARE', value: resourceTaskName }
+        { name: FORWARDER_IMAGE_SETTING, value: forwarderImage }
+        { name: CONTROL_PLANE_REGION_SETTING, value: controlPlaneLocation }
+        { name: PII_SCRUBBER_RULES_SETTING, value: piiScrubberRules }
+      ])
+      linuxFxVersion: 'Python|3.11'
+    }
+    publicNetworkAccess: 'Enabled'
+    httpsOnly: true
+  }
+  dependsOn: [fileServices]
+}
+
+resource deployerTaskEnv 'Microsoft.App/managedEnvironments@2024-03-01' = {
+  name: 'dd-log-forwarder-env-${controlPlaneId}-${controlPlaneLocation}'
+  location: controlPlaneLocation
+  properties: {}
+}
+
+var deployerTaskName = 'deployer-task-${controlPlaneId}'
+
+resource deployerTask 'Microsoft.App/jobs@2024-03-01' = {
+  name: deployerTaskName
+  location: controlPlaneLocation
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    environmentId: deployerTaskEnv.id
+    configuration: {
+      triggerType: 'Schedule'
+      scheduleTriggerConfig: {
+        cronExpression: '*/30 * * * *'
+      }
+      replicaRetryLimit: 1
+      replicaTimeout: 1800
+      secrets: [
+        { name: CONNECTION_STRING_SECRET, value: connectionString }
+        { name: DD_API_KEY_SECRET, value: datadogApiKey }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: deployerTaskName
+          image: deployerTaskImage
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+          env: [
+            { name: STORAGE_CONNECTION_SETTING, secretRef: CONNECTION_STRING_SECRET }
+            { name: SUBSCRIPTION_ID_SETTING, value: controlPlaneSubscriptionId }
+            { name: RESOURCE_GROUP_SETTING, value: controlPlaneResourceGroupName }
+            { name: CONTROL_PLANE_ID_SETTING, value: controlPlaneId }
+            { name: CONTROL_PLANE_REGION_SETTING, value: controlPlaneLocation }
+            { name: DD_API_KEY_SETTING, secretRef: DD_API_KEY_SECRET }
+            { name: DD_SITE_SETTING, value: datadogSite }
+            { name: DD_TELEMETRY_SETTING, value: datadogTelemetry ? 'true' : 'false' }
+            { name: STORAGE_ACCOUNT_URL_SETTING, value: storageAccountUrl }
+            { name: LOG_LEVEL_SETTING, value: logLevel }
+          ]
+        }
+      ]
+    }
+  }
+}
+
+resource websiteContributorRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
+  scope: resourceGroup()
+  // Details: https://www.azadvertizer.net/azrolesadvertizer/de139f84-1756-47ae-9be6-808fbbe84772.html
+  name: 'de139f84-1756-47ae-9be6-808fbbe84772'
+}
+
+resource deployerTaskRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid('deployer', controlPlaneId)
+  scope: resourceGroup()
+  properties: {
+    description: 'ddlfo${controlPlaneId}'
+    roleDefinitionId: websiteContributorRole.id
+    principalId: deployerTask.identity.principalId
+  }
+}
+
+// DEPLOYER TASK INITIAL RUN
+
+resource initialRunIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: 'initialRunIdentity${controlPlaneId}'
+  location: controlPlaneLocation
+}
+
+var containerAppStartRoleName = 'ContainerAppStartRole${controlPlaneId}'
+
+resource containerAppStartRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
+  name: guid(containerAppStartRoleName)
+  properties: {
+    roleName: containerAppStartRoleName
+    description: 'Custom role to start container app jobs'
+    type: 'customRole'
+    permissions: [{ actions: ['Microsoft.App/jobs/start/action'] }]
+    assignableScopes: [resourceGroup().id]
+  }
+}
+
+resource initialRunContainerAppRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid('initialRunContainerAppRoleAssignment', controlPlaneId)
+  properties: {
+    description: 'ddlfo${controlPlaneId}'
+    roleDefinitionId: containerAppStartRole.id
+    principalId: initialRunIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+output resourceTaskPrincipalId string = resourceTask.identity.principalId
+output diagnosticSettingsTaskPrincipalId string = diagnosticSettingsTask.identity.principalId
+output scalingTaskPrincipalId string = scalingTask.identity.principalId
+output initialRunIdentityPrincipalId string = initialRunIdentity.properties.principalId
+output initialRunIdentityId string = initialRunIdentity.id
+output storageAccountName string = storageAccount.name

--- a/azure/logging_install/bicep/control_plane_resource_group.bicep
+++ b/azure/logging_install/bicep/control_plane_resource_group.bicep
@@ -1,0 +1,8 @@
+targetScope = 'subscription'
+param controlPlaneResourceGroup string
+param controlPlaneLocation string
+
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+  name: controlPlaneResourceGroup
+  location: controlPlaneLocation
+}

--- a/azure/logging_install/bicep/createUiDefinition.json
+++ b/azure/logging_install/bicep/createUiDefinition.json
@@ -1,0 +1,265 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
+  "handler": "Microsoft.Azure.CreateUIDef",
+  "version": "0.1.2-preview",
+  "parameters": {
+    "basics": [
+      {
+        "name": "armio",
+        "type": "Microsoft.Solutions.ArmApiControl",
+        "request": {
+          "method": "POST",
+          "path": "/providers/Microsoft.Management/getEntities?api-version=2020-05-01"
+        }
+      },
+      {
+        "name": "monitoredSubscriptions",
+        "type": "Microsoft.Common.DropDown",
+        "label": "Subscriptions to Forward Logs",
+        "filterPlaceholder": "Select Subscriptions to Enable Log Forwarding",
+        "filter": true,
+        "multiselect": true,
+        "selectAll": true,
+        "defaultValue": "[map(filter(steps('basics').armio.value,(i)=>and(not(equals(i.type, 'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions, 'noaccess'),equals(i.properties.inheritedPermissions, 'noaccess')))  )), (item)=> parse(concat('{\"label\":\"', item.properties.displayName, '\",\"value\":\"', item.name, '\"}')))]",
+        "constraints": {
+          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=>and(not(equals(i.type, 'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions, 'noaccess'),equals(i.properties.inheritedPermissions, 'noaccess')))  )), (item)=> parse(concat('{\"label\":\"', item.properties.displayName, '\",\"value\":\"', item.name, '\"}')))]",
+          "required": true
+        },
+        "visible": true
+      },
+      {
+        "name": "controlPlaneInfo",
+        "type": "Microsoft.Common.InfoBox",
+        "visible": true,
+        "options": {
+          "icon": "Info",
+          "text": "The Control Plane is a set of resources that will be deployed to a single subscription. The Control Plane will be used to manage the log forwarding scaling and configuration across all subscriptions. The region selected above will be where the Control Plane resources are deployed. Resources in all regions will have logs forwarded to Datadog."
+        }
+      },
+      {
+        "name": "controlPlaneSubscription",
+        "type": "Microsoft.Common.DropDown",
+        "label": "Control Plane Subscription",
+        "toolTip": "Subscription to deploy the Control Plane resources",
+        "filterPlaceholder": "Select subscription to deploy the Control Plane resources",
+        "filter": true,
+        "multiselect": false,
+        "selectAll": false,
+        "constraints": {
+          "allowedValues": "[map(filter(steps('basics').armio.value,(i)=>and(not(equals(i.type, 'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions, 'noaccess'),equals(i.properties.inheritedPermissions, 'noaccess')))  )), (item)=> parse(concat('{\"label\":\"', item.properties.displayName, '\",\"value\":\"', item.name, '\"}')))]",
+          "required": true
+        },
+        "visible": true
+      },
+      {
+        "name": "resourceGroup",
+        "type": "Microsoft.Common.TextBox",
+        "label": "Resource Group Name",
+        "toolTip": "Resource Group to deploy the Control Plane resources",
+        "defaultValue": "datadog-log-forwarding",
+        "placeholder": "datadog-log-forwarding",
+        "constraints": {
+          "required": true,
+          "regex": "^[-\\w\\._\\(\\)]+$",
+          "validationMessage": "Must be a valid Resource Group Name"
+        },
+        "visible": true
+      },
+      {
+        "name": "infoResourceGroup",
+        "type": "Microsoft.Common.InfoBox",
+        "visible": true,
+        "options": {
+          "icon": "Warning",
+          "text": "This resource group will be used across all subscriptions for the Control Plane and Forwarders. It is recommended to not re-use an existing resource group name for simpler management and cleanup."
+        }
+      }
+    ],
+    "steps": [
+      {
+        "name": "datadogConfig",
+        "label": "Datadog Configuration",
+        "elements": [
+          {
+            "name": "datadogIntegration",
+            "type": "Microsoft.Common.Section",
+            "label": "Datadog Organization",
+            "elements": [
+              {
+                "name": "textBlock1",
+                "type": "Microsoft.Common.TextBlock",
+                "visible": true,
+                "options": {
+                  "text": "To fill out the fields below, copy the API key from your Datadog org. You can find your API Key in the Access section of the Organization Settings.",
+                  "link": {
+                    "label": "Learn more",
+                    "uri": "https://docs.datadoghq.com/account_management/org_settings/"
+                  }
+                }
+              },
+              {
+                "name": "datadogApiKey",
+                "type": "Microsoft.Common.PasswordBox",
+                "label": {
+                  "password": "Datadog API Key",
+                  "confirmPassword": "Re-enter Datadog Api Key"
+                },
+                "toolTip": "Your Datadog API key",
+                "constraints": {
+                  "required": true,
+                  "regex": "^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$).*",
+                  "validationMessage": "Must be a valid API Key (not a Key ID)."
+                },
+                "options": {
+                  "hideConfirmation": true
+                },
+                "visible": true
+              },
+              {
+                "name": "datadogSite",
+                "type": "Microsoft.Common.DropDown",
+                "label": "Datadog Site",
+                "defaultValue": "US1",
+                "toolTip": "The datadog site where you login to the datadog app.",
+                "constraints": {
+                  "allowedValues": [
+                    {
+                      "label": "US1",
+                      "value": "datadoghq.com"
+                    },
+                    {
+                      "label": "US3",
+                      "value": "us3.datadoghq.com"
+                    },
+                    {
+                      "label": "US5",
+                      "value": "us5.datadoghq.com"
+                    },
+                    {
+                      "label": "EU1",
+                      "value": "datadoghq.eu"
+                    },
+                    {
+                      "label": "AP1",
+                      "value": "ap1.datadoghq.com"
+                    },
+                    {
+                      "label": "AP2",
+                      "value": "ap2.datadoghq.com"
+                    },
+                    {
+                      "label": "US1-FED",
+                      "value": "ddog-gov.com"
+                    }
+                  ],
+                  "required": false
+                },
+                "visible": true
+              }
+            ],
+            "visible": true
+          },
+          {
+            "name": "tagFiltering",
+            "type": "Microsoft.Common.Section",
+            "label": "Filter Resources by Tags",
+            "elements": [
+              {
+                "name": "textBlock1",
+                "type": "Microsoft.Common.TextBlock",
+                "visible": true,
+                "options": {
+                  "text": "Optional - To include or exclude certain resources for log forwarding, enter Azure resource tags below in comma-separated format. Inclusive tags can be written as-is. Excluding tags must be prefixed with '!'"
+                }
+              },
+              {
+                "name": "resourceTagFilters",
+                "type": "Microsoft.Common.TextBox",
+                "label": "Tag Filters",
+                "toolTip": "Resources with any inclusion tag will send logs to Datadog. Resources with any exclusion tag will not send logs to Datadog. If a resource has both inclusion and exclusion tags, the exclusion tags take precedence. Wildcards are supported - use '*' to match multiple characters or '?' for a single character.",
+                "placeholder": "env:prod,datadog:true,!datadog:false",
+                "constraints": {
+                  "required": false,
+                  "regex": "^$|^[^,]+(?:,[^,]+)*$",
+                  "validationMessage": "Must be a comma-separated list of tags. Ensure there are no leading or trailing commas. Inclusive tags should be written normally while excluding tags should be prefixed with '!'"
+                },
+                "visible": true
+              }
+            ]
+          },
+          {
+            "name": "logsPiiFiltering",
+            "type": "Microsoft.Common.Section",
+            "label": "Logs PII Filtering",
+            "elements": [
+              {
+                "name": "textBlock1",
+                "type": "Microsoft.Common.TextBlock",
+                "visible": true,
+                "options": {
+                  "text": "Optional - To replace PII in your forwarded logs, enter a YAML config of regular expression patterns with corresponding replacement strings. Regular expressions must adhere to the RE2 standard."
+                }
+              },
+              {
+                "name": "piiFilterConfigs",
+                "type": "Microsoft.Common.TextBox",
+                "label": "PII Filtering Configurations",
+                "toolTip": "YAML format required. Rule names must be unique. Each rule must define pattern and replacement fields. Single quotes must surround the values for pattern and replacement. If your pattern or replacement values contain a single quote within, escape it by using two single quotes.",
+                "placeholder": "redact_ip_address:\n pattern: '[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}'\n replacement: 'x.x.x.x'",
+                "multiLine": true,
+                "constraints": {
+                  "required": false,
+                  "regex": "^(?:[A-Za-z0-9_-]+(?: [A-Za-z0-9_-]+)*:\r?\n(\\s+)pattern: '.*'\\s*\n(\\1)replacement: '.*'\\s*\n?\\s*)*$",
+                  "validationMessage": "Must be valid YAML or empty. Rule names must consist of alphanumeric characters, underscores, or dashes. Each rule must define \"pattern\" and \"replacement\" fields where their value is encased in single quotes. Ensure there is a space after each key-value colon. Double-check that indentation is the same under each rule."
+                },
+                "visible": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "deployment",
+        "label": "Deployment",
+        "elements": [
+          {
+            "name": "deploymentSection",
+            "type": "Microsoft.Common.Section",
+            "label": "Deployment",
+            "elements": [
+              {
+                "name": "deploymentInfo",
+                "type": "Microsoft.Common.InfoBox",
+                "visible": true,
+                "options": {
+                  "icon": "Warning",
+                  "text": "During the deployment process, diagnostic settings will be applied to all monitored resources. This action will trigger restarts of App Services, including Web Apps and Function Apps."
+                }
+              },
+              {
+                "name": "deployAcknowledgment",
+                "label": "I acknowledge the warning above",
+                "type": "Microsoft.Common.CheckBox",
+                "visible": true,
+                "constraints": {
+                  "required": true,
+                  "validationMessage": "You must acknowledge the warning above to proceed"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": {
+      "monitoredSubscriptions": "[string(steps('basics').monitoredSubscriptions)]",
+      "controlPlaneLocation": "[location()]",
+      "controlPlaneSubscriptionId": "[steps('basics').controlPlaneSubscription]",
+      "controlPlaneResourceGroupName": "[steps('basics').resourceGroup]",
+      "datadogApiKey": "[steps('datadogConfig').datadogIntegration.datadogApiKey]",
+      "datadogSite": "[steps('datadogConfig').datadogIntegration.datadogSite]",
+      "resourceTagFilters": "[steps('datadogConfig').tagFiltering.resourceTagFilters]",
+      "piiScrubberRules": "[steps('datadogConfig').logsPiiFiltering.piiFilterConfigs]"
+    }
+  }
+}

--- a/azure/logging_install/bicep/forwarder.bicep
+++ b/azure/logging_install/bicep/forwarder.bicep
@@ -1,0 +1,151 @@
+// This will deploy just the forwarder container app + storage account needed for the forwarder to work.
+// Automated log forwarding setup and scaling will not be set up.
+targetScope = 'resourceGroup'
+
+@description('Name of the Container App Managed Environment for the Forwarder')
+@minLength(2)
+@maxLength(60)
+param environmentName string = 'datadog-log-forwarder-env'
+
+@description('Name of the Forwarder Container App Job')
+@minLength(1)
+@maxLength(260)
+param jobName string = 'datadog-log-forwarder'
+
+@description('Name of the Log Storage Account')
+@minLength(3)
+@maxLength(24)
+param storageAccountName string = 'datadoglogstorage'
+
+@description('The SKU of the storage account')
+@allowed([
+  'Premium_LRS'
+  'Premium_ZRS'
+  'Standard_GRS'
+  'Standard_GZRS'
+  'Standard_LRS'
+  'Standard_RAGRS'
+  'Standard_RAGZRS'
+  'Standard_ZRS'
+])
+param storageAccountSku string = 'Standard_LRS'
+
+@description('The number of days to retain logs (and internal metrics) in the storage account')
+@minValue(1)
+param storageAccountRetentionDays int = 1
+
+@secure()
+@description('Datadog API Key')
+@minLength(32)
+@maxLength(32)
+param datadogApiKey string
+
+@allowed([
+  'datadoghq.com'
+  'datadoghq.eu'
+  'ap1.datadoghq.com'
+  'ap2.datadoghq.com'
+  'us3.datadoghq.com'
+  'us5.datadoghq.com'
+  'ddog-gov.com'
+])
+param datadogSite string = 'datadoghq.com'
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageAccountName
+  location: resourceGroup().location
+  sku: {
+    name: storageAccountSku
+  }
+  kind: 'StorageV2'
+  properties: {
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+resource storageManagementPolicy 'Microsoft.Storage/storageAccounts/managementPolicies@2023-05-01' = {
+  name: 'default'
+  parent: storageAccount
+  properties: {
+    policy: {
+      rules: [
+        {
+          enabled: true
+          name: 'Delete Old Blobs'
+          type: 'Lifecycle'
+          definition: {
+            actions: {
+              baseBlob: {
+                delete: {
+                  daysAfterModificationGreaterThan: storageAccountRetentionDays
+                }
+              }
+              snapshot: {
+                delete: {
+                  daysAfterCreationGreaterThan: storageAccountRetentionDays
+                }
+              }
+            }
+            filters: {
+              blobTypes: [
+                'blockBlob'
+                'appendBlob'
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource forwarderEnvironment 'Microsoft.App/managedEnvironments@2024-03-01' = {
+  name: environmentName
+  location: resourceGroup().location
+  properties: {}
+}
+
+resource forwarder 'Microsoft.App/jobs@2023-05-01' = {
+  name: jobName
+  location: resourceGroup().location
+  properties: {
+    environmentId: forwarderEnvironment.id
+    configuration: {
+      triggerType: 'Schedule'
+      replicaTimeout: 1800
+      replicaRetryLimit: 1
+      scheduleTriggerConfig: {
+        cronExpression: '* * * * *'
+        parallelism: 1
+        replicaCompletionCount: 1
+      }
+      secrets: [
+        {
+          name: 'storage-connection-string'
+          value: 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
+        }
+        { name: 'dd-api-key', value: datadogApiKey }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'datadog-forwarder'
+          image: 'datadoghq.azurecr.io/forwarder:latest'
+          resources: {
+            cpu: 1
+            memory: '2Gi'
+          }
+          env: [
+            { name: 'AzureWebJobsStorage', secretRef: 'storage-connection-string' }
+            { name: 'DD_API_KEY', secretRef: 'dd-api-key' }
+            { name: 'DD_SITE', value: datadogSite }
+            { name: 'CONTROL_PLANE_ID', value: 'none' }
+            { name: 'CONFIG_ID', value: resourceId('Microsoft.App/jobs', jobName) }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/azure/logging_install/bicep/initial_run.bicep
+++ b/azure/logging_install/bicep/initial_run.bicep
@@ -1,0 +1,56 @@
+param initialRunIdentity string
+param controlPlaneId string
+param storageAccountName string
+@secure()
+param datadogApiKey string
+param datadogSite string
+param datadogTelemetry bool
+param logLevel string
+param monitoredSubscriptions string
+param forwarderImage string
+param piiScrubberRules string
+param resourceTagFilters string
+param storageAccountUrl string
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' existing = {
+  name: storageAccountName
+}
+var storageAccountKey = listKeys(storageAccount.id, '2019-06-01').keys[0].value
+var connectionString = 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccountKey}'
+
+resource initialRun 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
+  name: 'initialRun'
+  location: resourceGroup().location
+  kind: 'AzureCLI'
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: { '${initialRunIdentity}': {} }
+  }
+  properties: {
+    storageAccountSettings: {
+      // reuse the storage account from before
+      storageAccountName: storageAccount.name
+      storageAccountKey: storageAccountKey
+    }
+    environmentVariables: [
+      { name: 'AzureWebJobsStorage', secureValue: connectionString }
+      { name: 'DD_API_KEY', secureValue: datadogApiKey }
+      { name: 'DD_SITE', value: datadogSite }
+      { name: 'DD_TELEMETRY', value: datadogTelemetry ? 'true' : 'false' }
+      { name: 'CONTROL_PLANE_ID', value: controlPlaneId }
+      { name: 'FORWARDER_IMAGE', value: forwarderImage }
+      { name: 'CONTROL_PLANE_REGION', value: resourceGroup().location }
+      { name: 'RESOURCE_GROUP', value: resourceGroup().name }
+      { name: 'SUBSCRIPTION_ID', value: subscription().subscriptionId }
+      { name: 'LOG_LEVEL', value: logLevel }
+      { name: 'MONITORED_SUBSCRIPTIONS', value: monitoredSubscriptions }
+      { name: 'PII_SCRUBBER_RULES', value: piiScrubberRules }
+      { name: 'RESOURCE_TAG_FILTERS', value: resourceTagFilters }
+    ]
+    azCliVersion: '2.67.0'
+    primaryScriptUri: '${storageAccountUrl}/lfo/initial_run.sh'
+    timeout: 'PT30M'
+    retentionInterval: 'PT1H'
+    cleanupPreference: 'OnSuccess'
+  }
+}

--- a/azure/logging_install/bicep/resource_group_permissions.bicep
+++ b/azure/logging_install/bicep/resource_group_permissions.bicep
@@ -1,0 +1,48 @@
+targetScope = 'resourceGroup'
+
+param controlPlaneId string
+param diagnosticSettingsTaskPrincipalId string
+param scalingTaskPrincipalId string
+param initialRunPrincipalId string
+
+resource readerAndDataAccessRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
+  scope: resourceGroup()
+  // Details: https://www.azadvertizer.net/azrolesadvertizer/c12c1c16-33a1-487b-954d-41c89c60f349.html
+  name: 'c12c1c16-33a1-487b-954d-41c89c60f349'
+}
+
+resource contributorRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
+  scope: resourceGroup()
+  // Details: https://www.azadvertizer.net/azrolesadvertizer/b24988ac-6180-42a0-ab88-20f7382dd24c.html
+  name: 'b24988ac-6180-42a0-ab88-20f7382dd24c'
+}
+
+resource diagnosticSettingsTaskStorageRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, 'storage', 'diagnosticSettings', controlPlaneId)
+  scope: resourceGroup()
+  properties: {
+    description: 'ddlfo${controlPlaneId}'
+    roleDefinitionId: readerAndDataAccessRole.id
+    principalId: diagnosticSettingsTaskPrincipalId
+  }
+}
+
+resource scalingTaskRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, 'scaling', controlPlaneId)
+  scope: resourceGroup()
+  properties: {
+    description: 'ddlfo${controlPlaneId}'
+    roleDefinitionId: contributorRole.id
+    principalId: scalingTaskPrincipalId
+  }
+}
+
+resource initialRunRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, 'initialRunContributor', controlPlaneId)
+  scope: resourceGroup()
+  properties: {
+    description: 'ddlfo${controlPlaneId}'
+    roleDefinitionId: contributorRole.id
+    principalId: initialRunPrincipalId
+  }
+}

--- a/azure/logging_install/bicep/subscription_permissions.bicep
+++ b/azure/logging_install/bicep/subscription_permissions.bicep
@@ -1,0 +1,66 @@
+targetScope = 'subscription'
+
+param resourceGroupName string
+param location string
+param controlPlaneId string
+param resourceTaskPrincipalId string
+param diagnosticSettingsTaskPrincipalId string
+param scalingTaskPrincipalId string
+param initialRunIdentityPrincipalId string
+
+// create the resource group for the forwarders in this subscription
+resource forwarderResourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+  name: resourceGroupName
+  location: location
+}
+
+// assign the resource group level permissions
+module resourceGroupPermissions './resource_group_permissions.bicep' = {
+  name: 'resourceGroupPermissions-${controlPlaneId}'
+  scope: forwarderResourceGroup
+  params: {
+    controlPlaneId: controlPlaneId
+    diagnosticSettingsTaskPrincipalId: diagnosticSettingsTaskPrincipalId
+    scalingTaskPrincipalId: scalingTaskPrincipalId
+    initialRunPrincipalId: initialRunIdentityPrincipalId
+  }
+}
+
+resource monitoringReaderRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
+  scope: subscription()
+  // Details: https://www.azadvertizer.net/azrolesadvertizer/43d0d8ad-25c7-4714-9337-8ba259a9fe05.html
+  name: '43d0d8ad-25c7-4714-9337-8ba259a9fe05'
+}
+resource monitoringContributorRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
+  scope: subscription()
+  // Details: https://www.azadvertizer.net/azrolesadvertizer/749f88d5-cbae-40b8-bcfc-e573ddc772fa.html
+  name: '749f88d5-cbae-40b8-bcfc-e573ddc772fa'
+}
+
+resource resourceTaskRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, 'resourceTask', controlPlaneId)
+  properties: {
+    description: 'ddlfo${controlPlaneId}'
+    roleDefinitionId: monitoringReaderRole.id
+    principalId: resourceTaskPrincipalId
+  }
+}
+
+resource diagnosticSettingsTaskMonitorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, 'monitor', 'diagnosticSettings', controlPlaneId)
+  properties: {
+    description: 'ddlfo${controlPlaneId}'
+    roleDefinitionId: monitoringContributorRole.id
+    principalId: diagnosticSettingsTaskPrincipalId
+  }
+}
+
+
+resource initialRunMonitorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, 'initialRunMonitoringContributor', controlPlaneId)
+  properties: {
+    description: 'ddlfo${controlPlaneId}'
+    roleDefinitionId: monitoringContributorRole.id
+    principalId: initialRunIdentityPrincipalId
+  }
+}

--- a/azure/logging_install/bicep/validate_config.bicep
+++ b/azure/logging_install/bicep/validate_config.bicep
@@ -1,0 +1,46 @@
+targetScope = 'resourceGroup'
+
+@secure()
+param datadogApiKey string
+param datadogSite string
+param piiScrubberRules string
+
+resource validateConfigScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  name: 'validateConfigScript'
+  location: resourceGroup().location
+  kind: 'AzureCLI'
+  properties: {
+    azCliVersion: '2.67.0'
+    environmentVariables: [
+      { name: 'DD_API_KEY', secureValue: datadogApiKey }
+      { name: 'DD_SITE', value: datadogSite }
+      { name: 'PII_SCRUBBER_RULES', value: piiScrubberRules }
+    ]
+    scriptContent: '''
+      # Validate Datadog API key with chosen site
+      tdnf install -y jq
+      response=$(curl -X GET "https://api.${DD_SITE}/api/v1/validate" \
+        -H "Accept: application/json" \
+        -H "DD-API-KEY: ${DD_API_KEY}" 2>/dev/null)
+      if [ "$(jq .valid <<<"$response")" != 'true' ]; then
+        echo "{\"Result\": {\"error\": \"Unable to validate API Key against Site '${DD_SITE}'. Please check that the correct Datadog host site was used and that the key is a valid Datadog API key found at https://app.datadoghq.com/organization-settings/api-keys\", \"response\": $response}}" | jq | tee "$AZ_SCRIPTS_OUTPUT_PATH"
+        exit 1
+      fi
+
+      if [[ -z "$PII_SCRUBBER_RULES" ]]; then
+        exit 0
+      fi
+
+      # Validate PII rules are parseable YAML
+      curl -sSLo /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && chmod +x /usr/local/bin/yq
+      yq_output=$(echo "$PII_SCRUBBER_RULES" | yq '.' 2>&1)
+      if [ $? -ne 0 ]; then
+        echo "{\"Result\": {\"error\": \"Invalid YAML. Please provide a valid YAML file.\", \"details\": \"$yq_output\"}}" | jq | tee "$AZ_SCRIPTS_OUTPUT_PATH"
+        exit 1
+      fi
+    '''
+    timeout: 'PT30M'
+    cleanupPreference: 'OnSuccess'
+    retentionInterval: 'PT1H'
+  }
+}

--- a/azure/logging_install/terraform/standalone/forwarder.tf
+++ b/azure/logging_install/terraform/standalone/forwarder.tf
@@ -1,0 +1,284 @@
+# Variables
+variable "environment_name" {
+  description = "Name of the Container App Managed Environment for the Forwarder"
+  type        = string
+  default     = "datadog-log-forwarder-env"
+
+  validation {
+    condition     = length(var.environment_name) >= 2 && length(var.environment_name) <= 60
+    error_message = "Environment name must be between 2 and 60 characters long."
+  }
+}
+
+variable "job_name" {
+  description = "Name of the Forwarder Container App Job"
+  type        = string
+  default     = "datadog-log-forwarder"
+
+  validation {
+    condition     = length(var.job_name) >= 1 && length(var.job_name) <= 260
+    error_message = "Job name must be between 1 and 260 characters long."
+  }
+}
+
+variable "storage_account_name" {
+  description = "Name of the Log Storage Account"
+  type        = string
+  default     = "datadoglogstorage"
+
+  validation {
+    condition     = length(var.storage_account_name) >= 3 && length(var.storage_account_name) <= 24
+    error_message = "Storage account name must be between 3 and 24 characters long."
+  }
+}
+
+variable "storage_account_sku" {
+  description = "The SKU of the storage account"
+  type        = string
+  default     = "Standard_LRS"
+
+  validation {
+    condition = contains([
+      "Premium_LRS",
+      "Premium_ZRS",
+      "Standard_GRS",
+      "Standard_GZRS",
+      "Standard_LRS",
+      "Standard_ZRS"
+    ], var.storage_account_sku)
+    error_message = "Storage account SKU must be one of the allowed values."
+  }
+}
+
+variable "storage_account_retention_days" {
+  description = "The number of days to retain logs (and internal metrics) in the storage account"
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.storage_account_retention_days >= 1
+    error_message = "Storage account retention days must be at least 1."
+  }
+}
+
+variable "datadog_api_key" {
+  description = "Datadog API Key"
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = length(var.datadog_api_key) == 32
+    error_message = "Datadog API key must be exactly 32 characters long."
+  }
+}
+
+variable "datadog_site" {
+  description = "Datadog Site"
+  type        = string
+  default     = "datadoghq.com"
+
+  validation {
+    condition = contains([
+      "datadoghq.com",
+      "datadoghq.eu",
+      "ap1.datadoghq.com",
+      "ap2.datadoghq.com",
+      "us3.datadoghq.com",
+      "us5.datadoghq.com",
+      "ddog-gov.com",
+      "datad0g.com",
+    ], var.datadog_site)
+    error_message = "Datadog site must be one of the allowed values."
+  }
+}
+
+variable "location" {
+  description = "Azure region where resources will be created"
+  type        = string
+  default     = "East US"
+}
+
+variable "resource_group_name" {
+  description = "Name of the resource group where resources will be created"
+  type        = string
+}
+
+variable "forwarder_image" {
+  description = "Container image for the forwarder"
+  type        = string
+  default     = "datadoghq.azurecr.io/forwarder:latest"
+}
+
+variable "forwarder_cpu" {
+  description = "CPU allocation for the forwarder container"
+  type        = number
+  default     = 2
+}
+
+variable "forwarder_memory" {
+  description = "Memory allocation for the forwarder container"
+  type        = string
+  default     = "4Gi"
+}
+
+variable "schedule_expression" {
+  description = "Cron expression for the forwarder job schedule"
+  type        = string
+  default     = "* * * * *"
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+# Data source for current resource group
+data "azurerm_resource_group" "current" {
+  name = var.resource_group_name
+}
+
+# Storage Account
+resource "azurerm_storage_account" "forwarder_storage" {
+  name                     = var.storage_account_name
+  resource_group_name      = data.azurerm_resource_group.current.name
+  location                 = var.location
+  account_tier             = split("_", var.storage_account_sku)[0]
+  account_replication_type = split("_", var.storage_account_sku)[1]
+  account_kind             = "StorageV2"
+  min_tls_version          = "TLS1_2"
+  https_traffic_only_enabled = true
+
+  tags = var.tags
+}
+
+# Storage Account Management Policy
+resource "azurerm_storage_management_policy" "forwarder_lifecycle" {
+  storage_account_id = azurerm_storage_account.forwarder_storage.id
+
+  rule {
+    name    = "delete-old-blobs"
+    enabled = true
+
+    filters {
+      blob_types = ["blockBlob", "appendBlob"]
+    }
+
+    actions {
+      base_blob {
+        delete_after_days_since_modification_greater_than = var.storage_account_retention_days
+      }
+      snapshot {
+        delete_after_days_since_creation_greater_than = var.storage_account_retention_days
+      }
+    }
+  }
+}
+
+# Container App Environment
+resource "azurerm_container_app_environment" "forwarder_env" {
+  name                = var.environment_name
+  location            = var.location
+  resource_group_name = data.azurerm_resource_group.current.name
+
+  tags = var.tags
+}
+
+# Local values for connection string
+locals {
+  storage_connection_string = "DefaultEndpointsProtocol=https;AccountName=${azurerm_storage_account.forwarder_storage.name};EndpointSuffix=core.windows.net;AccountKey=${azurerm_storage_account.forwarder_storage.primary_access_key}"
+}
+
+# Data source for current client config
+data "azurerm_client_config" "current" {}
+
+# Container App Job
+resource "azurerm_container_app_job" "forwarder" {
+  name                         = var.job_name
+  location                     = var.location
+  resource_group_name          = data.azurerm_resource_group.current.name
+  container_app_environment_id = azurerm_container_app_environment.forwarder_env.id
+
+  replica_timeout_in_seconds = 1800
+  replica_retry_limit        = 1
+
+  schedule_trigger_config {
+    cron_expression                = var.schedule_expression
+    parallelism                    = 1
+    replica_completion_count       = 1
+  }
+
+  template {
+    container {
+      name   = "datadog-forwarder"
+      image  = var.forwarder_image
+      cpu    = var.forwarder_cpu
+      memory = var.forwarder_memory
+
+      env {
+        name        = "AzureWebJobsStorage"
+        secret_name = "storage-connection-string"
+      }
+      env {
+        name        = "DD_API_KEY"
+        secret_name = "dd-api-key"
+      }
+      env {
+        name  = "DD_SITE"
+        value = var.datadog_site
+      }
+      env {
+        name  = "CONTROL_PLANE_ID"
+        value = "none"
+      }
+      env {
+        name  = "CONFIG_ID"
+        value = "standalone-forwarder"
+      }
+    }
+  }
+
+  secret {
+    name  = "storage-connection-string"
+    value = local.storage_connection_string
+  }
+
+  secret {
+    name  = "dd-api-key"
+    value = var.datadog_api_key
+  }
+
+  tags = var.tags
+}
+
+# Outputs
+output "storage_account_name" {
+  description = "Name of the created storage account"
+  value       = azurerm_storage_account.forwarder_storage.name
+}
+
+output "storage_account_id" {
+  description = "ID of the created storage account"
+  value       = azurerm_storage_account.forwarder_storage.id
+}
+
+output "storage_account_primary_access_key" {
+  description = "Primary access key of the storage account"
+  value       = azurerm_storage_account.forwarder_storage.primary_access_key
+  sensitive   = true
+}
+
+output "container_app_environment_id" {
+  description = "ID of the container app environment"
+  value       = azurerm_container_app_environment.forwarder_env.id
+}
+
+output "container_app_job_id" {
+  description = "ID of the container app job"
+  value       = azurerm_container_app_job.forwarder.id
+}
+
+output "container_app_job_name" {
+  description = "Name of the container app job"
+  value       = azurerm_container_app_job.forwarder.name
+}

--- a/azure/logging_install/terraform/standalone/provider.tf
+++ b/azure/logging_install/terraform/standalone/provider.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
+provider "azurerm" {
+  features {}
+}

--- a/azure/logging_install/terraform/standalone/terraform.tfvars.example
+++ b/azure/logging_install/terraform/standalone/terraform.tfvars.example
@@ -1,0 +1,23 @@
+# Required variables
+resource_group_name = "my-datadog-forwarder-rg"
+datadog_api_key     = "your-32-character-datadog-api-key"
+
+# Optional variables with custom values
+location                      = "East US"
+environment_name              = "datadog-log-forwarder-env"
+job_name                      = "datadog-log-forwarder"
+storage_account_name          = "datadogLogStorage"  # Must be globally unique
+storage_account_sku           = "Standard_LRS"
+storage_account_retention_days = 7
+datadog_site                  = "datadoghq.com"
+forwarder_image               = "datadoghq.azurecr.io/forwarder:latest"
+forwarder_cpu                 = 2
+forwarder_memory              = "4Gi"
+schedule_expression           = "* * * * *"  # Run every minute
+
+# Tags
+tags = {
+  Environment = "production"
+  Project     = "datadog-log-forwarding"
+  Owner       = "devops-team"
+}


### PR DESCRIPTION
Azure will allowlist this repository such that we will be able to use our ARM/BICEP templates and CreateUIDefinition assets. See incident-40771. Copied from [here](https://github.com/DataDog/azure-log-forwarding-orchestration/tree/main/deploy).