### PR TITLE
TON-XXXX: Publish Per Package Releases From Main

### DIFF
--- a/.github/chainguard/self.release.create-release.sts.yaml
+++ b/.github/chainguard/self.release.create-release.sts.yaml
@@ -1,0 +1,13 @@
+---
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/integrations-management:ref:refs/heads/main
+
+claim_pattern:
+  event_name: push
+  ref: refs/heads/main
+  ref_protected: "true"
+  workflow_ref: DataDog/integrations-management/\.github/workflows/release\.yaml@refs/heads/main
+
+permissions:
+  contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,12 @@ jobs:
   release:
     name: release (${{ matrix.cloud }}/${{ matrix.package }})
     runs-on: ubuntu-latest
+    # Serialize per-package so two pushes touching the same package don't both
+    # compute the same next-patch version and collide on `gh release create`.
+    # Different packages still release in parallel.
+    concurrency:
+      group: release-${{ matrix.cloud }}-${{ matrix.package }}
+      cancel-in-progress: false
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,26 +23,29 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # `sources` declares every path whose changes must trigger a rebuild.
-          # Mirrors what each build.sh actually copies into the zipapp; keep them in sync.
+          # `sources` lists only paths whose changes affect the built artifact:
+          # the package's src/, its build.sh, anything else that build.sh copies
+          # in (e.g. logging_install/src for the azure quickstart, bicep/ for
+          # logging_install), shared/src, and dev_requirements.txt. Tests, READMEs,
+          # and other adjacent files do not bump the version.
           - cloud: azure
             package: agentless
-            sources: "agentless/ shared/ dev_requirements.txt"
+            sources: "agentless/src/ agentless/build.sh shared/src/ dev_requirements.txt"
           - cloud: azure
             package: integration_quickstart
-            sources: "integration_quickstart/ logging_install/src/ shared/ dev_requirements.txt"
+            sources: "integration_quickstart/src/ integration_quickstart/build.sh logging_install/src/ shared/src/ dev_requirements.txt"
           - cloud: azure
             package: logging_install
-            sources: "logging_install/ shared/ dev_requirements.txt"
+            sources: "logging_install/src/ logging_install/bicep/ logging_install/build.sh shared/src/ dev_requirements.txt"
           - cloud: gcp
             package: agentless
-            sources: "agentless/ shared/ dev_requirements.txt"
+            sources: "agentless/src/ agentless/build.sh shared/src/ dev_requirements.txt"
           - cloud: gcp
             package: integration_quickstart
-            sources: "integration_quickstart/ shared/ dev_requirements.txt"
+            sources: "integration_quickstart/src/ integration_quickstart/build.sh shared/src/ dev_requirements.txt"
           - cloud: gcp
             package: log_forwarding_quickstart
-            sources: "log_forwarding_quickstart/ shared/ dev_requirements.txt"
+            sources: "log_forwarding_quickstart/src/ log_forwarding_quickstart/build.sh shared/src/ dev_requirements.txt"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,68 @@ on:
 permissions: {}
 
 jobs:
+  # First job: figure out which packages actually changed in this push and emit
+  # a matrix containing only those. Keeps no-op release jobs from ever entering
+  # the per-package concurrency group, which would otherwise cancel a pending
+  # real release for that package (GH Actions concurrency keeps only one
+  # pending job per group).
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.compute.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: compute
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+        run: |
+          CHANGED_FILES=$(git diff --name-only "$BEFORE" "$AFTER")
+          MATRIX_ENTRIES=()
+
+          # Returns 0 (and appends to MATRIX_ENTRIES) iff this push touched any
+          # of the listed source paths for the given package.
+          check_package() {
+            local cloud="$1"
+            local package="$2"
+            local sources="$3"
+            local src pattern
+            for src in $sources; do
+              if [[ "$src" == */ ]]; then
+                pattern="^${cloud}/${src}"
+              else
+                pattern="^${cloud}/${src}\$"
+              fi
+              if echo "$CHANGED_FILES" | grep -qE "$pattern"; then
+                MATRIX_ENTRIES+=("{\"cloud\":\"$cloud\",\"package\":\"$package\"}")
+                return 0
+              fi
+            done
+          }
+
+          # `sources` mirrors what each build.sh actually copies into the zipapp,
+          # plus the build script itself. Tests, READMEs, terraform/, etc. are
+          # intentionally excluded so doc-only and test-only PRs are no-ops.
+          check_package azure agentless                "agentless/src/ agentless/build.sh shared/src/ dev_requirements.txt"
+          check_package azure integration_quickstart   "integration_quickstart/src/ integration_quickstart/build.sh logging_install/src/ shared/src/ dev_requirements.txt"
+          check_package azure logging_install          "logging_install/src/ logging_install/bicep/ logging_install/build.sh shared/src/ dev_requirements.txt"
+          check_package gcp   agentless                "agentless/src/ agentless/build.sh shared/src/ dev_requirements.txt"
+          check_package gcp   integration_quickstart   "integration_quickstart/src/ integration_quickstart/build.sh shared/src/ dev_requirements.txt"
+          check_package gcp   log_forwarding_quickstart "log_forwarding_quickstart/src/ log_forwarding_quickstart/build.sh shared/src/ dev_requirements.txt"
+
+          if [ ${#MATRIX_ENTRIES[@]} -eq 0 ]; then
+            MATRIX="[]"
+          else
+            MATRIX="[$(IFS=,; printf '%s' "${MATRIX_ENTRIES[*]}")]"
+          fi
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
   release:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.matrix != '[]'
     name: release (${{ matrix.cloud }}/${{ matrix.package }})
     runs-on: ubuntu-latest
     # Serialize per-package so two pushes touching the same package don't both
@@ -22,68 +83,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # `sources` lists only paths whose changes affect the built artifact:
-          # the package's src/, its build.sh, anything else that build.sh copies
-          # in (e.g. logging_install/src for the azure quickstart, bicep/ for
-          # logging_install), shared/src, and dev_requirements.txt. Tests, READMEs,
-          # and other adjacent files do not bump the version.
-          - cloud: azure
-            package: agentless
-            sources: "agentless/src/ agentless/build.sh shared/src/ dev_requirements.txt"
-          - cloud: azure
-            package: integration_quickstart
-            sources: "integration_quickstart/src/ integration_quickstart/build.sh logging_install/src/ shared/src/ dev_requirements.txt"
-          - cloud: azure
-            package: logging_install
-            sources: "logging_install/src/ logging_install/bicep/ logging_install/build.sh shared/src/ dev_requirements.txt"
-          - cloud: gcp
-            package: agentless
-            sources: "agentless/src/ agentless/build.sh shared/src/ dev_requirements.txt"
-          - cloud: gcp
-            package: integration_quickstart
-            sources: "integration_quickstart/src/ integration_quickstart/build.sh shared/src/ dev_requirements.txt"
-          - cloud: gcp
-            package: log_forwarding_quickstart
-            sources: "log_forwarding_quickstart/src/ log_forwarding_quickstart/build.sh shared/src/ dev_requirements.txt"
+        include: ${{ fromJSON(needs.detect-changes.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0   # full history for git diff against previous push
+          fetch-depth: 0   # full history so git tag --list sees every release
           fetch-tags: true # need every release tag for version computation
 
-      - name: Did this package change?
-        id: changed
-        env:
-          BEFORE: ${{ github.event.before }}
-          AFTER: ${{ github.event.after }}
-          SOURCES: ${{ matrix.sources }}
-        run: |
-          CHANGED_FILES=$(git diff --name-only "$BEFORE" "$AFTER")
-          RELEASE=false
-          for src in $SOURCES; do
-            # Trailing slash = directory prefix; no slash = exact file match
-            if [[ "$src" == */ ]]; then
-              PATTERN="^${{ matrix.cloud }}/${src}"
-            else
-              PATTERN="^${{ matrix.cloud }}/${src}\$"
-            fi
-            if echo "$CHANGED_FILES" | grep -qE "$PATTERN"; then
-              RELEASE=true
-              break
-            fi
-          done
-          echo "changed=$RELEASE" >> "$GITHUB_OUTPUT"
-
       - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
-        if: steps.changed.outputs.changed == 'true'
         id: octo-sts
         with:
           scope: DataDog/integrations-management
           policy: self.release.create-release
 
       - name: Compute next version
-        if: steps.changed.outputs.changed == 'true'
         id: version
         run: |
           PREFIX="${{ matrix.cloud }}-${{ matrix.package }}-v"
@@ -103,24 +116,20 @@ jobs:
           echo "tag=${PREFIX}${NEXT}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-python@v5
-        if: steps.changed.outputs.changed == 'true'
         with:
           python-version: '3.9'
           cache: pip
           cache-dependency-path: ${{ matrix.cloud }}/dev_requirements.txt
 
       - name: Install dependencies
-        if: steps.changed.outputs.changed == 'true'
         working-directory: ${{ matrix.cloud }}
         run: pip install -r dev_requirements.txt
 
       - name: Build
-        if: steps.changed.outputs.changed == 'true'
         working-directory: ${{ matrix.cloud }}
         run: bash ${{ matrix.package }}/build.sh
 
       - name: Create release
-        if: steps.changed.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           # Pin the tag to the SHA we built, so it doesn't drift to whatever's

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,127 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  release:
+    name: release (${{ matrix.cloud }}/${{ matrix.package }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # `sources` declares every path whose changes must trigger a rebuild.
+          # Mirrors what each build.sh actually copies into the zipapp; keep them in sync.
+          - cloud: azure
+            package: agentless
+            sources: "agentless/ shared/ dev_requirements.txt"
+          - cloud: azure
+            package: integration_quickstart
+            sources: "integration_quickstart/ logging_install/src/ shared/ dev_requirements.txt"
+          - cloud: azure
+            package: logging_install
+            sources: "logging_install/ shared/ dev_requirements.txt"
+          - cloud: gcp
+            package: agentless
+            sources: "agentless/ shared/ dev_requirements.txt"
+          - cloud: gcp
+            package: integration_quickstart
+            sources: "integration_quickstart/ shared/ dev_requirements.txt"
+          - cloud: gcp
+            package: log_forwarding_quickstart
+            sources: "log_forwarding_quickstart/ shared/ dev_requirements.txt"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history for git diff against previous push
+          fetch-tags: true # need every release tag for version computation
+
+      - name: Did this package change?
+        id: changed
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+          SOURCES: ${{ matrix.sources }}
+        run: |
+          CHANGED_FILES=$(git diff --name-only "$BEFORE" "$AFTER")
+          RELEASE=false
+          for src in $SOURCES; do
+            # Trailing slash = directory prefix; no slash = exact file match
+            if [[ "$src" == */ ]]; then
+              PATTERN="^${{ matrix.cloud }}/${src}"
+            else
+              PATTERN="^${{ matrix.cloud }}/${src}\$"
+            fi
+            if echo "$CHANGED_FILES" | grep -qE "$PATTERN"; then
+              RELEASE=true
+              break
+            fi
+          done
+          echo "changed=$RELEASE" >> "$GITHUB_OUTPUT"
+
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        if: steps.changed.outputs.changed == 'true'
+        id: octo-sts
+        with:
+          scope: DataDog/integrations-management
+          policy: self.release.create-release
+
+      - name: Compute next version
+        if: steps.changed.outputs.changed == 'true'
+        id: version
+        run: |
+          PREFIX="${{ matrix.cloud }}-${{ matrix.package }}-v"
+          # Use local git tags (fetched via fetch-tags: true) so we don't pay
+          # the gh-release-list pagination tax and don't miss a tag because an
+          # unrelated package has churned out hundreds of releases since.
+          LATEST=$(git tag --list "${PREFIX}*" | sed "s|^${PREFIX}||" | sort -V | tail -1)
+          if [ -z "$LATEST" ]; then
+            NEXT="0.1.0"
+          else
+            MAJOR=$(echo "$LATEST" | cut -d. -f1)
+            MINOR=$(echo "$LATEST" | cut -d. -f2)
+            PATCH=$(echo "$LATEST" | cut -d. -f3)
+            NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))"
+          fi
+          echo "version=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "tag=${PREFIX}${NEXT}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-python@v5
+        if: steps.changed.outputs.changed == 'true'
+        with:
+          python-version: '3.9'
+          cache: pip
+          cache-dependency-path: ${{ matrix.cloud }}/dev_requirements.txt
+
+      - name: Install dependencies
+        if: steps.changed.outputs.changed == 'true'
+        working-directory: ${{ matrix.cloud }}
+        run: pip install -r dev_requirements.txt
+
+      - name: Build
+        if: steps.changed.outputs.changed == 'true'
+        working-directory: ${{ matrix.cloud }}
+        run: bash ${{ matrix.package }}/build.sh
+
+      - name: Create release
+        if: steps.changed.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          # Pin the tag to the SHA we built, so it doesn't drift to whatever's
+          # on main if another commit lands while this job is running.
+          TARGET_SHA: ${{ github.event.after }}
+        working-directory: ${{ matrix.cloud }}/${{ matrix.package }}/dist
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --repo DataDog/integrations-management \
+            --target "$TARGET_SHA" \
+            --title "${{ matrix.cloud }}/${{ matrix.package }} v${{ steps.version.outputs.version }}" \
+            --generate-notes \
+            *


### PR DESCRIPTION
# Summary

Stacked on #174. This PR adds a release pipeline that builds each package's `.pyz` and publishes it as a GitHub Release on every merge to main. The drift check from #174 is the temporary stopgap; this is the real fix.

Intent: once this lands, I will update the Datadog UI install flows to fetch `.pyz` files from release URLs (`releases/download/<tag>/<file>`) instead of the raw `dist/` paths in this repo. After the UI is migrated, I'll delete `dist/` directories from the repo entirely. CI becomes the source of truth for built artifacts; humans stop committing binaries.

How it works on every push to main:

1. Each matrix job (one per package) checks whether files matching `<cloud>/(<package>/|shared/|dev_requirements.txt)` changed in the push.
2. If nothing relevant changed, the job is a no-op.
3. If something changed, it lists existing releases tagged `<cloud>-<package>-v*`, finds the highest, bumps the patch, and uses that as the new tag.
4. Runs `bash <package>/build.sh` to build the `.pyz`.
5. Creates a GitHub Release with the build output attached and auto-generated notes.

First release for each package starts at `v0.1.0`. Subsequent merges that touch the package bump to `v0.1.1`, `v0.1.2`, etc. Doc-only or unrelated PRs don't trigger releases.

The per-package `build.sh` files stay in place. Inlining the build steps into the workflow would mean devs can no longer build locally without copy-pasting CI YAML, and every iteration on a script would require pushing a branch and waiting on CI. Keeping build.sh as the single source of truth that CI calls preserves the local dev loop.

Before this can run on main:
- The `dd-octo-sts` policy needs to be onboarded by Datadog's platform team for this repo. Same flow as helm-charts.
- Branch protection on main (the policy requires `ref_protected: "true"`).