### PR TITLE
TON-XXXX: Publish Per Package Releases From Main

### DIFF
--- a/.github/chainguard/self.release.create-release.sts.yaml
+++ b/.github/chainguard/self.release.create-release.sts.yaml
@@ -1,0 +1,13 @@
+---
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/integrations-management:ref:refs/heads/main
+
+claim_pattern:
+  event_name: push
+  ref: refs/heads/main
+  ref_protected: "true"
+  workflow_ref: DataDog/integrations-management/\.github/workflows/release\.yaml@refs/heads/main
+
+permissions:
+  contents: write

--- a/.github/chainguard/self.release.create-release.sts.yaml
+++ b/.github/chainguard/self.release.create-release.sts.yaml
@@ -4,7 +4,7 @@ issuer: https://token.actions.githubusercontent.com
 subject: repo:DataDog/integrations-management:ref:refs/heads/main
 
 claim_pattern:
-  event_name: push
+  event_name: push|workflow_dispatch
   ref: refs/heads/main
   ref_protected: "true"
   workflow_ref: DataDog/integrations-management/\.github/workflows/release\.yaml@refs/heads/main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,145 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  # First job: figure out which packages actually changed in this push and emit
+  # a matrix containing only those. Keeps no-op release jobs from ever entering
+  # the per-package concurrency group, which would otherwise cancel a pending
+  # real release for that package (GH Actions concurrency keeps only one
+  # pending job per group).
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.compute.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: compute
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+        run: |
+          CHANGED_FILES=$(git diff --name-only "$BEFORE" "$AFTER")
+          MATRIX_ENTRIES=()
+
+          # Returns 0 (and appends to MATRIX_ENTRIES) iff this push touched any
+          # of the listed source paths for the given package.
+          check_package() {
+            local cloud="$1"
+            local package="$2"
+            local sources="$3"
+            local src pattern
+            for src in $sources; do
+              if [[ "$src" == */ ]]; then
+                pattern="^${cloud}/${src}"
+              else
+                pattern="^${cloud}/${src}\$"
+              fi
+              if echo "$CHANGED_FILES" | grep -qE "$pattern"; then
+                MATRIX_ENTRIES+=("{\"cloud\":\"$cloud\",\"package\":\"$package\"}")
+                return 0
+              fi
+            done
+          }
+
+          # `sources` mirrors what each build.sh actually copies into the zipapp,
+          # plus the build script itself. Tests, READMEs, terraform/, etc. are
+          # intentionally excluded so doc-only and test-only PRs are no-ops.
+          check_package azure agentless                "agentless/src/ agentless/build.sh shared/src/ dev_requirements.txt"
+          check_package azure integration_quickstart   "integration_quickstart/src/ integration_quickstart/build.sh logging_install/src/ shared/src/ dev_requirements.txt"
+          check_package azure logging_install          "logging_install/src/ logging_install/bicep/ logging_install/build.sh shared/src/ dev_requirements.txt"
+          check_package gcp   agentless                "agentless/src/ agentless/build.sh shared/src/ dev_requirements.txt"
+          check_package gcp   integration_quickstart   "integration_quickstart/src/ integration_quickstart/build.sh shared/src/ dev_requirements.txt"
+          check_package gcp   log_forwarding_quickstart "log_forwarding_quickstart/src/ log_forwarding_quickstart/build.sh shared/src/ dev_requirements.txt"
+
+          if [ ${#MATRIX_ENTRIES[@]} -eq 0 ]; then
+            MATRIX="[]"
+          else
+            MATRIX="[$(IFS=,; printf '%s' "${MATRIX_ENTRIES[*]}")]"
+          fi
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+  release:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.matrix != '[]'
+    name: release (${{ matrix.cloud }}/${{ matrix.package }})
+    runs-on: ubuntu-latest
+    # Serialize per-package so two pushes touching the same package don't both
+    # compute the same next-patch version and collide on `gh release create`.
+    # Different packages still release in parallel.
+    concurrency:
+      group: release-${{ matrix.cloud }}-${{ matrix.package }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.detect-changes.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so git tag --list sees every release
+          fetch-tags: true # need every release tag for version computation
+
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/integrations-management
+          policy: self.release.create-release
+
+      - name: Compute next version
+        id: version
+        run: |
+          PREFIX="${{ matrix.cloud }}-${{ matrix.package }}-v"
+          # Use local git tags (fetched via fetch-tags: true) so we don't pay
+          # the gh-release-list pagination tax and don't miss a tag because an
+          # unrelated package has churned out hundreds of releases since.
+          LATEST=$(git tag --list "${PREFIX}*" | sed "s|^${PREFIX}||" | sort -V | tail -1)
+          if [ -z "$LATEST" ]; then
+            NEXT="0.1.0"
+          else
+            MAJOR=$(echo "$LATEST" | cut -d. -f1)
+            MINOR=$(echo "$LATEST" | cut -d. -f2)
+            PATCH=$(echo "$LATEST" | cut -d. -f3)
+            NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))"
+          fi
+          echo "version=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "tag=${PREFIX}${NEXT}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          cache: pip
+          cache-dependency-path: ${{ matrix.cloud }}/dev_requirements.txt
+
+      - name: Install dependencies
+        working-directory: ${{ matrix.cloud }}
+        run: pip install -r dev_requirements.txt
+
+      - name: Build
+        working-directory: ${{ matrix.cloud }}
+        run: bash ${{ matrix.package }}/build.sh
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          # Pin the tag to the SHA we built, so it doesn't drift to whatever's
+          # on main if another commit lands while this job is running.
+          TARGET_SHA: ${{ github.event.after }}
+        working-directory: ${{ matrix.cloud }}/${{ matrix.package }}/dist
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --repo DataDog/integrations-management \
+            --target "$TARGET_SHA" \
+            --title "${{ matrix.cloud }}/${{ matrix.package }} v${{ steps.version.outputs.version }}" \
+            --generate-notes \
+            *

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,9 @@ name: Release
 on:
   push:
     branches: [main]
+  # Manual trigger so we can re-release everything from current main if needed
+  # (botched merge, missing release for a package, etc).
+  workflow_dispatch:
 
 permissions: {}
 
@@ -20,21 +23,48 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true # we look at existing tags to decide what to bootstrap
 
       - id: compute
         env:
+          EVENT: ${{ github.event_name }}
           BEFORE: ${{ github.event.before }}
           AFTER: ${{ github.event.after }}
         run: |
-          CHANGED_FILES=$(git diff --name-only "$BEFORE" "$AFTER")
+          # On workflow_dispatch we have no commit range, so include everything
+          # and let the per-package version step pick the right next tag.
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            CHANGED_FILES=""
+            FORCE_ALL=true
+          else
+            CHANGED_FILES=$(git diff --name-only "$BEFORE" "$AFTER")
+            FORCE_ALL=false
+          fi
+
           MATRIX_ENTRIES=()
 
-          # Returns 0 (and appends to MATRIX_ENTRIES) iff this push touched any
-          # of the listed source paths for the given package.
+          # Includes a package in the matrix if any of:
+          #   - workflow_dispatch (force all)
+          #   - no existing release tag for the package (bootstrap first release)
+          #   - this push touched a source path for the package
           check_package() {
             local cloud="$1"
             local package="$2"
             local sources="$3"
+            local entry="{\"cloud\":\"$cloud\",\"package\":\"$package\"}"
+
+            if [ "$FORCE_ALL" = "true" ]; then
+              MATRIX_ENTRIES+=("$entry")
+              return 0
+            fi
+
+            # Bootstrap: package has never been released, always include it on
+            # the first push the workflow sees.
+            if ! git tag --list "${cloud}-${package}-v*" | grep -q .; then
+              MATRIX_ENTRIES+=("$entry")
+              return 0
+            fi
+
             local src pattern
             for src in $sources; do
               if [[ "$src" == */ ]]; then
@@ -43,7 +73,7 @@ jobs:
                 pattern="^${cloud}/${src}\$"
               fi
               if echo "$CHANGED_FILES" | grep -qE "$pattern"; then
-                MATRIX_ENTRIES+=("{\"cloud\":\"$cloud\",\"package\":\"$package\"}")
+                MATRIX_ENTRIES+=("$entry")
                 return 0
               fi
             done
@@ -134,7 +164,9 @@ jobs:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           # Pin the tag to the SHA we built, so it doesn't drift to whatever's
           # on main if another commit lands while this job is running.
-          TARGET_SHA: ${{ github.event.after }}
+          # github.event.after is set on push; falls back to github.sha for
+          # workflow_dispatch (which has no commit range).
+          TARGET_SHA: ${{ github.event.after || github.sha }}
         working-directory: ${{ matrix.cloud }}/${{ matrix.package }}/dist
         run: |
           gh release create "${{ steps.version.outputs.tag }}" \


### PR DESCRIPTION
# Summary

Stacked on #174, this PR introduces a release pipeline that builds each package’s `.pyz` and publishes it as a GitHub Release on every merge to `main`. The drift check from #174 was a temporary safeguard—this is the long-term fix.

The main goal is to remove the need for reviewers to manually build scripts locally. Once this lands, releases will be fully automated on merges to `main`. I’ll also follow up by updating the Datadog UI for each team and removing the `dist/` directories from the repo.

## Intent

After this is merged, the Datadog UI install flows will be updated to fetch `.pyz` files directly from GitHub Release URLs (`releases/download/<tag>/<file>`) instead of referencing raw `dist/` paths in the repo. Once that migration is complete, the `dist/` directories will be removed entirely.

At that point, CI becomes the single source of truth for build artifacts—no more committing binaries manually.

## How it works

On every push to `main`:

1. Each matrix job (one per package) checks whether files matching  
   `<cloud>/(<package>/|shared/|dev_requirements.txt)` changed.
2. If nothing relevant changed, the job exits early.
3. If there are changes:
   - It looks up existing releases tagged `<cloud>-<package>-v*`
   - Finds the latest version
   - Bumps the patch version for the new release
4. Runs `bash <package>/build.sh` to build the `.pyz`.
5. Publishes a GitHub Release with the built artifact and auto-generated notes.

## Versioning

- The first release for each package starts at `v0.1.0`
- Subsequent updates increment the patch version (`v0.1.1`, `v0.1.2`, etc.)
- Changes that don’t affect a package (e.g., docs-only updates) won’t trigger a release

## Why keep `build.sh`?

Each package’s `build.sh` remains the source of truth for building artifacts.

Inlining build steps directly into the CI workflow would make local development harder—developers would need to copy CI config or push changes just to test builds. Keeping `build.sh` allows for a fast local dev loop while still letting CI handle automation.