### PR TITLE
ci: publish a rolling `<package>-latest` release alongside each versioned release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -245,6 +245,18 @@ jobs:
           # pinning a version. --latest=false keeps it from competing with
           # versioned releases for the repo-wide "Latest release" badge on the
           # GitHub UI.
+          #
+          # Gate the rolling update on this version being the current highest
+          # for the package. Without this guard, rerunning an old failed build
+          # after a newer release has already shipped would silently roll
+          # consumers backward to the older artifact.
+          PREFIX="${{ matrix.cloud }}-${{ matrix.package }}-v"
+          HIGHEST=$(git tag --list "${PREFIX}*" | sed "s|^${PREFIX}||" | sort -V | tail -1)
+          if [ "$HIGHEST" != "${{ steps.version.outputs.version }}" ]; then
+            echo "Skipping rolling-latest update: $VERSIONED_TAG is not the highest version (highest is ${PREFIX}${HIGHEST})."
+            exit 0
+          fi
+
           if gh release view "$LATEST_TAG" --repo "$REPO" >/dev/null 2>&1; then
             sync_release_assets "$LATEST_TAG"
             git tag -f "$LATEST_TAG" "$TARGET_SHA"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,8 +128,26 @@ jobs:
 
       - name: Compute next version
         id: version
+        env:
+          TARGET_SHA: ${{ github.event.after || github.sha }}
         run: |
           PREFIX="${{ matrix.cloud }}-${{ matrix.package }}-v"
+
+          # Idempotency: if a versioned tag for this package already points at
+          # the SHA we're building, reuse it instead of minting a new version.
+          # Otherwise a rerun (e.g. after a transient rolling-latest failure)
+          # would publish another versioned release for an identical commit
+          # and inflate the version on every recovery attempt.
+          for tag in $(git tag --list "${PREFIX}*"); do
+            if [ "$(git rev-list -n1 "$tag")" = "$TARGET_SHA" ]; then
+              EXISTING="${tag#$PREFIX}"
+              echo "version=$EXISTING" >> "$GITHUB_OUTPUT"
+              echo "tag=$tag" >> "$GITHUB_OUTPUT"
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+
           # Use local git tags (fetched via fetch-tags: true) so we don't pay
           # the gh-release-list pagination tax and don't miss a tag because an
           # unrelated package has churned out hundreds of releases since.
@@ -144,6 +162,7 @@ jobs:
           fi
           echo "version=$NEXT" >> "$GITHUB_OUTPUT"
           echo "tag=${PREFIX}${NEXT}" >> "$GITHUB_OUTPUT"
+          echo "exists=false" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-python@v5
         with:
@@ -170,13 +189,19 @@ jobs:
           LATEST_TAG: ${{ matrix.cloud }}-${{ matrix.package }}-latest
         working-directory: ${{ matrix.cloud }}/${{ matrix.package }}/dist
         run: |
-          # Immutable, versioned release for audit/rollback.
-          gh release create "${{ steps.version.outputs.tag }}" \
-            --repo DataDog/integrations-management \
-            --target "$TARGET_SHA" \
-            --title "${{ matrix.cloud }}/${{ matrix.package }} v${{ steps.version.outputs.version }}" \
-            --generate-notes \
-            *
+          # Immutable, versioned release for audit/rollback. Skip if an
+          # existing versioned tag already points at this SHA (recovery rerun
+          # for a previously-published version).
+          if [ "${{ steps.version.outputs.exists }}" = "false" ]; then
+            gh release create "${{ steps.version.outputs.tag }}" \
+              --repo DataDog/integrations-management \
+              --target "$TARGET_SHA" \
+              --title "${{ matrix.cloud }}/${{ matrix.package }} v${{ steps.version.outputs.version }}" \
+              --generate-notes \
+              *
+          else
+            echo "Versioned release ${{ steps.version.outputs.tag }} already exists for $TARGET_SHA; skipping create and proceeding to rolling-latest update."
+          fi
 
           # Rolling "latest" release per package, so consumers can curl a stable
           # URL (releases/download/<cloud>-<package>-latest/<file>) without pinning

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,16 +180,29 @@ jobs:
 
           # Rolling "latest" release per package, so consumers can curl a stable URL
           # (releases/download/<cloud>-<package>-latest/<file>) without pinning a
-          # version. Delete the previous latest release + tag, then re-create.
-          # --latest=false keeps it from competing with versioned releases for the
-          # repo-wide "Latest release" badge on the GitHub UI.
-          gh release delete "$LATEST_TAG" \
-            --repo DataDog/integrations-management \
-            --yes --cleanup-tag 2>/dev/null || true
-          gh release create "$LATEST_TAG" \
-            --repo DataDog/integrations-management \
-            --target "$TARGET_SHA" \
-            --title "${{ matrix.cloud }}/${{ matrix.package }} (latest)" \
-            --notes "Rolling pointer to ${{ steps.version.outputs.tag }}." \
-            --latest=false \
-            *
+          # version. Update assets in place rather than delete-then-recreate so
+          # the URL never 404s if a step fails partway. --latest=false keeps it
+          # from competing with versioned releases for the repo-wide "Latest
+          # release" badge on the GitHub UI.
+          if gh release view "$LATEST_TAG" --repo DataDog/integrations-management >/dev/null 2>&1; then
+            # Overwrite assets in place, then move the underlying tag to the
+            # new SHA. The release never disappears between iterations.
+            gh release upload "$LATEST_TAG" \
+              --repo DataDog/integrations-management \
+              --clobber \
+              *
+            git tag -f "$LATEST_TAG" "$TARGET_SHA"
+            # Force-push the moved tag using the dd-octo-sts token (the
+            # default origin remote was set up with GITHUB_TOKEN, which won't
+            # have contents:write).
+            git push --force "https://x-access-token:${GH_TOKEN}@github.com/DataDog/integrations-management.git" "$LATEST_TAG"
+          else
+            # First time for this package: create the rolling release.
+            gh release create "$LATEST_TAG" \
+              --repo DataDog/integrations-management \
+              --target "$TARGET_SHA" \
+              --title "${{ matrix.cloud }}/${{ matrix.package }} (latest)" \
+              --notes "Rolling pointer to ${{ steps.version.outputs.tag }}." \
+              --latest=false \
+              *
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -178,23 +178,40 @@ jobs:
             --generate-notes \
             *
 
-          # Rolling "latest" release per package, so consumers can curl a stable URL
-          # (releases/download/<cloud>-<package>-latest/<file>) without pinning a
-          # version. Update assets in place rather than delete-then-recreate so
-          # the URL never 404s if a step fails partway. --latest=false keeps it
-          # from competing with versioned releases for the repo-wide "Latest
-          # release" badge on the GitHub UI.
+          # Rolling "latest" release per package, so consumers can curl a stable
+          # URL (releases/download/<cloud>-<package>-latest/<file>) without pinning
+          # a version. --latest=false keeps it from competing with versioned
+          # releases for the repo-wide "Latest release" badge on the GitHub UI.
+          #
+          # Caveat: `gh release upload --clobber` deletes the existing asset
+          # before re-uploading. If the upload fails after the delete, the asset
+          # is missing until a future workflow run replaces it. We retry to
+          # absorb transient API failures, which are the realistic risk; a hard
+          # failure across all retries surfaces as a workflow failure rather
+          # than going silent.
+          upload_with_retry() {
+            local attempt
+            for attempt in 1 2 3; do
+              if gh release upload "$LATEST_TAG" \
+                  --repo DataDog/integrations-management \
+                  --clobber \
+                  *; then
+                return 0
+              fi
+              echo "Upload attempt $attempt failed; retrying..." >&2
+              sleep $((attempt * 5))
+            done
+            return 1
+          }
+
           if gh release view "$LATEST_TAG" --repo DataDog/integrations-management >/dev/null 2>&1; then
             # Overwrite assets in place, then move the underlying tag to the
-            # new SHA. The release never disappears between iterations.
-            gh release upload "$LATEST_TAG" \
-              --repo DataDog/integrations-management \
-              --clobber \
-              *
+            # new SHA.
+            upload_with_retry
             git tag -f "$LATEST_TAG" "$TARGET_SHA"
-            # Force-push the moved tag using the dd-octo-sts token (the
-            # default origin remote was set up with GITHUB_TOKEN, which won't
-            # have contents:write).
+            # Force-push the moved tag using the dd-octo-sts token (the default
+            # origin remote was set up with GITHUB_TOKEN, which won't have
+            # contents:write).
             git push --force "https://x-access-token:${GH_TOKEN}@github.com/DataDog/integrations-management.git" "$LATEST_TAG"
           else
             # First time for this package: create the rolling release.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -167,11 +167,29 @@ jobs:
           # github.event.after is set on push; falls back to github.sha for
           # workflow_dispatch (which has no commit range).
           TARGET_SHA: ${{ github.event.after || github.sha }}
+          LATEST_TAG: ${{ matrix.cloud }}-${{ matrix.package }}-latest
         working-directory: ${{ matrix.cloud }}/${{ matrix.package }}/dist
         run: |
+          # Immutable, versioned release for audit/rollback.
           gh release create "${{ steps.version.outputs.tag }}" \
             --repo DataDog/integrations-management \
             --target "$TARGET_SHA" \
             --title "${{ matrix.cloud }}/${{ matrix.package }} v${{ steps.version.outputs.version }}" \
             --generate-notes \
+            *
+
+          # Rolling "latest" release per package, so consumers can curl a stable URL
+          # (releases/download/<cloud>-<package>-latest/<file>) without pinning a
+          # version. Delete the previous latest release + tag, then re-create.
+          # --latest=false keeps it from competing with versioned releases for the
+          # repo-wide "Latest release" badge on the GitHub UI.
+          gh release delete "$LATEST_TAG" \
+            --repo DataDog/integrations-management \
+            --yes --cleanup-tag 2>/dev/null || true
+          gh release create "$LATEST_TAG" \
+            --repo DataDog/integrations-management \
+            --target "$TARGET_SHA" \
+            --title "${{ matrix.cloud }}/${{ matrix.package }} (latest)" \
+            --notes "Rolling pointer to ${{ steps.version.outputs.tag }}." \
+            --latest=false \
             *

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,13 +137,14 @@ jobs:
           # the SHA we're building, reuse it instead of minting a new version.
           # Otherwise a rerun (e.g. after a transient rolling-latest failure)
           # would publish another versioned release for an identical commit
-          # and inflate the version on every recovery attempt.
+          # and inflate the version on every recovery attempt. Whether the
+          # corresponding release was actually published with assets is
+          # checked separately downstream — the tag alone doesn't imply that.
           for tag in $(git tag --list "${PREFIX}*"); do
             if [ "$(git rev-list -n1 "$tag")" = "$TARGET_SHA" ]; then
               EXISTING="${tag#$PREFIX}"
               echo "version=$EXISTING" >> "$GITHUB_OUTPUT"
               echo "tag=$tag" >> "$GITHUB_OUTPUT"
-              echo "exists=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
           done
@@ -162,7 +163,6 @@ jobs:
           fi
           echo "version=$NEXT" >> "$GITHUB_OUTPUT"
           echo "tag=${PREFIX}${NEXT}" >> "$GITHUB_OUTPUT"
-          echo "exists=false" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-python@v5
         with:
@@ -189,62 +189,75 @@ jobs:
           LATEST_TAG: ${{ matrix.cloud }}-${{ matrix.package }}-latest
         working-directory: ${{ matrix.cloud }}/${{ matrix.package }}/dist
         run: |
-          # Immutable, versioned release for audit/rollback. Skip if an
-          # existing versioned tag already points at this SHA (recovery rerun
-          # for a previously-published version).
-          if [ "${{ steps.version.outputs.exists }}" = "false" ]; then
-            gh release create "${{ steps.version.outputs.tag }}" \
-              --repo DataDog/integrations-management \
-              --target "$TARGET_SHA" \
-              --title "${{ matrix.cloud }}/${{ matrix.package }} v${{ steps.version.outputs.version }}" \
-              --generate-notes \
-              *
-          else
-            echo "Versioned release ${{ steps.version.outputs.tag }} already exists for $TARGET_SHA; skipping create and proceeding to rolling-latest update."
-          fi
+          REPO=DataDog/integrations-management
+          VERSIONED_TAG="${{ steps.version.outputs.tag }}"
 
-          # Rolling "latest" release per package, so consumers can curl a stable
-          # URL (releases/download/<cloud>-<package>-latest/<file>) without pinning
-          # a version. --latest=false keeps it from competing with versioned
-          # releases for the repo-wide "Latest release" badge on the GitHub UI.
-          #
-          # Caveat: `gh release upload --clobber` deletes the existing asset
-          # before re-uploading. If the upload fails after the delete, the asset
-          # is missing until a future workflow run replaces it. We retry to
-          # absorb transient API failures, which are the realistic risk; a hard
-          # failure across all retries surfaces as a workflow failure rather
-          # than going silent.
-          upload_with_retry() {
+          # Reconcile a release's assets with the current dist/ contents:
+          #   1. Delete assets that no longer exist in the current dir
+          #      (handles renamed/removed files between versions).
+          #   2. Re-upload everything with --clobber, retried to absorb
+          #      transient API blips. --clobber is non-atomic per asset:
+          #      a hard failure across all retries surfaces as a workflow
+          #      failure rather than silently leaving a missing asset.
+          sync_release_assets() {
+            local tag="$1"
+            local current_files=(*)
+            local existing
+            existing=$(gh release view "$tag" --repo "$REPO" \
+              --json assets --jq '.assets[].name' 2>/dev/null || true)
+            for asset in $existing; do
+              if ! printf '%s\n' "${current_files[@]}" | grep -qxF "$asset"; then
+                echo "Removing stale asset $asset from $tag"
+                gh release delete-asset "$tag" "$asset" \
+                  --repo "$REPO" --yes
+              fi
+            done
             local attempt
             for attempt in 1 2 3; do
-              if gh release upload "$LATEST_TAG" \
-                  --repo DataDog/integrations-management \
-                  --clobber \
-                  *; then
+              if gh release upload "$tag" --repo "$REPO" --clobber \
+                  "${current_files[@]}"; then
                 return 0
               fi
-              echo "Upload attempt $attempt failed; retrying..." >&2
+              echo "Upload attempt $attempt for $tag failed; retrying..." >&2
               sleep $((attempt * 5))
             done
             return 1
           }
 
-          if gh release view "$LATEST_TAG" --repo DataDog/integrations-management >/dev/null 2>&1; then
-            # Overwrite assets in place, then move the underlying tag to the
-            # new SHA.
-            upload_with_retry
+          # Immutable, versioned release for audit/rollback. Idempotent on
+          # rerun: if the release already exists (e.g. a previous run created
+          # it but failed mid-upload, leaving the tag in place but assets
+          # missing), reconcile its assets instead of skipping or duplicating.
+          if gh release view "$VERSIONED_TAG" --repo "$REPO" >/dev/null 2>&1; then
+            echo "Versioned release $VERSIONED_TAG already exists; reconciling assets."
+            sync_release_assets "$VERSIONED_TAG"
+          else
+            gh release create "$VERSIONED_TAG" \
+              --repo "$REPO" \
+              --target "$TARGET_SHA" \
+              --title "${{ matrix.cloud }}/${{ matrix.package }} v${{ steps.version.outputs.version }}" \
+              --generate-notes \
+              *
+          fi
+
+          # Rolling "latest" release per package, so consumers can curl a stable
+          # URL (releases/download/<cloud>-<package>-latest/<file>) without
+          # pinning a version. --latest=false keeps it from competing with
+          # versioned releases for the repo-wide "Latest release" badge on the
+          # GitHub UI.
+          if gh release view "$LATEST_TAG" --repo "$REPO" >/dev/null 2>&1; then
+            sync_release_assets "$LATEST_TAG"
             git tag -f "$LATEST_TAG" "$TARGET_SHA"
             # Force-push the moved tag using the dd-octo-sts token (the default
             # origin remote was set up with GITHUB_TOKEN, which won't have
             # contents:write).
-            git push --force "https://x-access-token:${GH_TOKEN}@github.com/DataDog/integrations-management.git" "$LATEST_TAG"
+            git push --force "https://x-access-token:${GH_TOKEN}@github.com/$REPO.git" "$LATEST_TAG"
           else
-            # First time for this package: create the rolling release.
             gh release create "$LATEST_TAG" \
-              --repo DataDog/integrations-management \
+              --repo "$REPO" \
               --target "$TARGET_SHA" \
               --title "${{ matrix.cloud }}/${{ matrix.package }} (latest)" \
-              --notes "Rolling pointer to ${{ steps.version.outputs.tag }}." \
+              --notes "Rolling pointer to $VERSIONED_TAG." \
               --latest=false \
               *
           fi


### PR DESCRIPTION
# Summary

Stacked on the release pipeline added in #176. After publishing the immutable versioned release (`<cloud>-<package>-vX.Y.Z`), the workflow also maintains a sibling rolling release tagged `<cloud>-<package>-latest` pointing at the same SHA with the same assets.

This gives consumers a stable URL to curl without having to pin a version:

```
https://github.com/DataDog/integrations-management/releases/download/gcp-integration_quickstart-latest/gcp_integration_quickstart.pyz
```

The web-ui side will be migrated separately to use these `-latest` URLs in place of `raw.githubusercontent.com/.../main/.../dist/<file>.pyz`. Once that lands, the `dist/` directories can be deleted from the repo.

# How it works

After the versioned release is created, the same step:

1. Checks whether the rolling release already exists.
2. If it does: overwrites the assets via `gh release upload --clobber` (with retries), then moves the underlying git tag to the new SHA via `git push --force`.
3. If it doesn't (first time the workflow sees this package): creates the release fresh.

`--latest=false` keeps the rolling release out of the running for GitHub's repo-wide "Latest release" badge, which always reflects whichever versioned release was most recently published.

# Failure modes and what we accept

`gh release upload --clobber` is not atomic: it deletes the existing same-named asset before uploading the new one. If the upload step fails after the delete, the rolling release is missing that asset until the next successful run (which could be days for an inactive package). The retry loop in the workflow absorbs transient API failures — the realistic risk — but doesn't eliminate the window for a hard failure across all attempts. In that case the workflow fails loudly rather than going silent, so it shows up as a red CI run someone has to address.

This was an explicit trade-off: getting to fully zero-window safety would mean either a pointer-file pattern (rolling release contains a tiny `version.txt`, consumers do a two-step fetch) or a staging-then-swap dance. Both are real changes to the consumer side. The retry loop is the pragmatic choice for now and the workflow's failure mode is observable.

# Reviewers

What changed:
- `.github/workflows/release.yaml`: after each versioned release, either creates the rolling `<cloud>-<package>-latest` release (first time) or overwrites its assets (with retries) and force-moves its tag (every subsequent time).

What to look at:
- The retry loop on the upload. Three attempts with linear backoff. If you want exponential or a different count, easy to change.
- The force-push of the tag uses the `dd-octo-sts` token explicitly rather than `origin`'s configured remote, since `actions/checkout` sets `origin` to use `GITHUB_TOKEN` which won't have `contents:write`. URL is constructed inline.
- `--clobber` overwrites by filename. None of our packages currently change asset filenames between versions, but if that ever changes, we'd need to also delete stale assets that aren't in the new set.