### PR TITLE
TON-XXXX: Add agent instructions and release-check skill

### DIFF
--- a/.claude/commands/release-check.md
+++ b/.claude/commands/release-check.md
@@ -1,0 +1,53 @@
+---
+description: Build, test, and verify dist/ is in sync for any packages with pending changes. Run before pushing.
+---
+
+You are validating that pending changes in this branch are ready to push, specifically that the committed `dist/` artifacts match the current `src/`. This is the same check CI's `dist drift` job runs, but local — fail fast before the push.
+
+## Steps
+
+1. Identify which packages have pending changes.
+
+   Run `git diff --name-only origin/main...HEAD` (and `git status -s` for unstaged/uncommitted changes). Map changed paths to packages:
+
+   - Anything under `<cloud>/<package>/src/` or `<cloud>/<package>/build.sh` → that package.
+   - Anything under `<cloud>/shared/src/` → all packages in that cloud.
+   - Anything under `azure/logging_install/src/` → also `azure/integration_quickstart` (its `build.sh` bundles `logging_install/src/`).
+   - Anything under `azure/logging_install/bicep/` → `azure/logging_install` (compiled to JSON).
+   - Anything under `<cloud>/dev_requirements.txt` → all packages in that cloud.
+
+2. For each affected package, run its build from the cloud parent directory:
+
+   ```bash
+   cd <cloud>
+   bash <package>/build.sh
+   ```
+
+3. For each affected package, run its tests:
+
+   ```bash
+   cd <cloud>
+   python -m pytest <package>/tests
+   ```
+
+   If `shared/src/` changed, also run `python -m pytest shared/tests` from the cloud parent.
+
+4. Check whether `dist/` files are dirty (i.e. the build produced different output than what's committed):
+
+   ```bash
+   git status -s -- '<cloud>/<package>/dist/'
+   ```
+
+   If `dist/` files are modified, commit them alongside the source changes. They MUST be in the same commit chain — CI rejects PRs where `dist/` is out of sync with `src/`.
+
+5. Report status to the user. For each affected package, one of:
+
+   - ✅ build clean, tests pass, `dist/` already committed.
+   - ⚠️  `dist/` was rebuilt and modified — needs to be committed before push.
+   - ❌ build failed or tests failed — investigate before pushing.
+
+## What this command does NOT do
+
+- It does not push. The user pushes when they're ready.
+- It does not bump release versions. The release workflow auto-bumps on merge to `main`.
+- It does not fix lint or formatting. Run `ruff check --fix <cloud>` separately if needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# Agent instructions for `integrations-management`
+
+These instructions apply to AI coding assistants (Claude Code, Cursor, etc.) working in this repo.
+
+## Repo shape
+
+This repo holds six self-contained Python packages, three per cloud:
+
+| Path                              | What it builds                                       |
+|-----------------------------------|------------------------------------------------------|
+| `azure/agentless`                 | `azure_agentless_setup.pyz`                          |
+| `azure/integration_quickstart`    | `azure_app_registration_quickstart.pyz`, `azure_log_forwarding_quickstart.pyz` |
+| `azure/logging_install`           | `azure_logging_install.pyz` + bicep JSONs            |
+| `gcp/agentless`                   | `gcp_agentless_setup.pyz`                            |
+| `gcp/integration_quickstart`      | `gcp_integration_quickstart.pyz`                     |
+| `gcp/log_forwarding_quickstart`   | `gcp_log_forwarding_quickstart.pyz`                  |
+
+Each package has:
+
+- `src/` — Python source.
+- `tests/` — pytest tests; conventionally run from the cloud parent directory (`cd azure && python -m pytest <package>/tests`) so cross-package imports like `shared.tests.test_data` resolve.
+- `build.sh` — packs `src/` (plus `shared/src/` and any other inputs) into a zipapp `.pyz` under `dist/`. For `azure/logging_install`, also compiles `bicep/*.bicep` to JSON.
+- `dist/` — committed build output. The CI drift-check job rebuilds and diffs against this; if `dist/` is out of sync with `src/`, CI fails.
+
+## Hard rule: build before pushing
+
+If you change anything under a package's `src/`, `build.sh`, or `<cloud>/shared/src/`, you MUST run that package's `build.sh` and commit the updated `dist/` together with the source change. CI's `dist drift` job will reject the PR otherwise.
+
+From the cloud parent directory:
+
+```bash
+cd azure   # or gcp
+bash <package>/build.sh
+```
+
+For `azure/integration_quickstart`, also run the build for `azure/integration_quickstart` if you changed `azure/logging_install/src/` (its `build.sh` bundles `logging_install/src/` into the quickstart zipapps).
+
+## Test before pushing
+
+```bash
+cd <cloud>
+python -m pytest <package>/tests
+```
+
+`shared/` and `agentless/` test suites depend on running from the cloud parent so the `pythonpath` in `pytest.ini` resolves shared modules.
+
+## Release flow (informational)
+
+Pushes to `main` that touch a package's source paths trigger `.github/workflows/release.yaml`:
+
+1. `detect-changes` decides which packages changed.
+2. Each affected package gets a versioned GitHub Release auto-published, tag format `<cloud>-<package>-vX.Y.Z`. The patch version auto-increments from the prior tag.
+3. Asset URL: `https://github.com/DataDog/integrations-management/releases/download/<cloud>-<package>-vX.Y.Z/<file>.pyz`.
+
+You don't need to do anything manually for releases — just follow the build-before-pushing rule above. Manual intervention only:
+
+- Major/minor bumps: create the tag manually (e.g. `gcp-agentless-v0.2.0`) before merging the PR.
+- Re-release everything from current main: `workflow_dispatch` on the Release workflow.
+
+## What to avoid
+
+- Don't edit files in `dist/` directly. They are build outputs.
+- Don't commit `__pycache__/`, `.ruff_cache/`, or `.DS_Store` into `src/`. The build scripts strip these from the zipapp, but they shouldn't be in source either.
+- Don't bypass the build step. CI will catch it but it wastes a round trip.


### PR DESCRIPTION
AGENTS.md documents the build-before-push rule and the package layout for AI assistants working in the repo.

.claude/commands/release-check.md gives Claude Code users a /release-check slash command that runs the build + tests + dist-drift verification locally, catching issues before CI does.