### PR TITLE
add(agentless): set CODEOWNERS for azure/agentless

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,5 @@ gcp/   @DataDog/gcp-integrations
 azure/storage_monitoring/    @DataDog/new-workloads
 
 # Agentless Scanning
-gcp/agentless/  @DataDog/k9-agentless
+azure/agentless/  @DataDog/k9-agentless
+gcp/agentless/    @DataDog/k9-agentless


### PR DESCRIPTION
Set CODEOWNERS for `azure/agentless/` following this PR review https://github.com/DataDog/integrations-management/pull/185#pullrequestreview-4266810751