### PR TITLE
fix(scaleway): clean up rotated IAM keys + accept-new for SSH host keys

### DIFF
--- a/scaleway/log_forwarding/setup-logs.sh
+++ b/scaleway/log_forwarding/setup-logs.sh
@@ -105,12 +105,8 @@
 #   SCW_INSTANCE_USER     SSH user for the Instance                    [default: root]
 #   SCW_ACCOUNT_NAME      Name for the Datadog integration account     [default: SCW_PROJECT_ID]
 #
-# For private-subnet audit-trail Instances, configure ProxyJump in
-# ~/.ssh/config so the script's ssh/scp calls tunnel transparently:
-#   Host my-private-vm
-#       HostName <private-ip>
-#       ProxyJump bastion@<gateway-ip>:61000
-# See https://www.scaleway.com/en/docs/public-gateways/how-to/use-ssh-bastion/
+# Private-subnet audit-trail Instances: configure ProxyJump in ~/.ssh/config.
+# https://www.scaleway.com/en/docs/public-gateways/how-to/use-ssh-bastion/
 #
 # ─────────────────────────────────────────────────────────────────────────────
 set -euo pipefail
@@ -313,9 +309,8 @@ IAM_ACCESS_KEY=""
 IAM_SECRET_KEY=""
 _IAM_OLD_KEYS=""
 _AUDIT_DEPLOYED=false
-# True when a collector might already be running with an existing key
-# (tagged Instance from a prior run, or BYO SCW_INSTANCE_IP).  Gates the
-# end-of-run cleanup so we don't revoke a key the live collector still uses.
+# Gates end-of-run IAM cleanup: true when a collector might still reference
+# a key (BYO SCW_INSTANCE_IP, or auto-provisioned tagged Instance).
 _PRE_EXISTING_AUDIT_INSTANCE=false
 # Cockpit Part 1 outcomes — used in main() to decide whether to register the
 # Datadog account.  If nothing worked, we skip Part 3 to avoid leaving a
@@ -871,15 +866,9 @@ _find_audit_instance() {
     | head -1
 }
 
-# True if any Instance tagged AUDIT_INSTANCE_TAG exists in this zone, regardless
-# of state.  Broader than _find_audit_instance (which is "running"-only) so the
-# end-of-run key cleanup gate also catches stopped/archived collectors whose
-# config files still reference an old key.
-#
-# Fail-safe on API errors: assume a collector might exist so cleanup preserves
-# its keys.  Calls scw directly (not _list_audit_instances_json) because that
-# helper swallows failures with `|| echo "[]"` — indistinguishable from a
-# legitimate empty result.
+# True if any tagged audit-trail Instance exists (any state), or if the scw
+# lookup fails — fail-safe so a transient API error never lets cleanup revoke
+# a live collector's keys.
 _has_tagged_audit_instance() {
   local output
   output=$(scw instance server list zone="$SCW_AUDIT_INSTANCE_ZONE" \
@@ -903,11 +892,9 @@ provision_audit_trail_instance() {
     return 0
   fi
 
-  # Detect a pre-existing tagged collector (running OR stopped) before honoring
-  # the PROVISION_INSTANCE=false / dry-run short-circuits below — otherwise an
-  # operator who auto-provisioned on a prior run and now opts out of
-  # provisioning would have the collector's IAM keys revoked by end-of-run
-  # cleanup.  Skipped in dry-run because the helper makes a live scw read.
+  # Probe for an existing collector before the opt-out / dry-run returns
+  # below, so re-runs with PROVISION_INSTANCE=false still preserve its keys.
+  # Skipped in dry-run (the helper makes a live scw read).
   if [[ "$DRY_RUN" != "true" ]]; then
     _has_tagged_audit_instance && _PRE_EXISTING_AUDIT_INSTANCE=true
   fi
@@ -1064,12 +1051,8 @@ setup_audit_trail() {
     || { warn "Failed to create temp dir — skipping audit trail setup"; return 1; }
   trap '[[ -n "${cid:-}" ]] && docker rm -f "$cid" >/dev/null 2>&1 || true; [[ -n "${work_dir:-}" ]] && rm -rf "$work_dir"' RETURN
 
-  # accept-new is TOFU on first contact (same security as the explicit
-  # ssh-keyscan it replaces) but defers to the user's ~/.ssh/config for
-  # ProxyJump, so private-subnet customers get bastion handling for free
-  # via their existing ssh config without needing script-specific env vars.
-  # Inherit the user's default UserKnownHostsFile so existing pins (target
-  # and bastion) are honored and accepted keys persist across runs.
+  # accept-new is TOFU on first contact and lets ssh use the user's
+  # ~/.ssh/config — so ProxyJump applies to every ssh/scp call.
   local -a ssh_opts=(-o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new)
 
   log "Verifying SSH access to ${SCW_INSTANCE_IP}..."
@@ -1240,11 +1223,9 @@ main() {
 
   register_datadog_account
 
-  # A deployed audit collector that was not redeployed this run still holds the
-  # old key, so revoking it would break log forwarding.  But if no prior
-  # collector exists at all (auto-provision path on first/failed attempts),
-  # there's nothing to break — clean up the staged old keys so they don't
-  # accumulate across runs.
+  # Preserve keys only when a collector might still reference one (just
+  # redeployed, or pre-existing).  Otherwise revoke them so first-run /
+  # failed-run keys don't accumulate.
   if [[ "$SCW_AUDIT_TRAIL_ENABLED" != "true" ]] \
      || [[ "$_AUDIT_DEPLOYED" == "true" ]] \
      || [[ "$_PRE_EXISTING_AUDIT_INSTANCE" != "true" ]]; then

--- a/scaleway/log_forwarding/setup-logs.sh
+++ b/scaleway/log_forwarding/setup-logs.sh
@@ -894,6 +894,15 @@ provision_audit_trail_instance() {
     return 0
   fi
 
+  # Detect a pre-existing tagged collector (running OR stopped) before honoring
+  # the PROVISION_INSTANCE=false / dry-run short-circuits below — otherwise an
+  # operator who auto-provisioned on a prior run and now opts out of
+  # provisioning would have the collector's IAM keys revoked by end-of-run
+  # cleanup.  Skipped in dry-run because the helper makes a live scw read.
+  if [[ "$DRY_RUN" != "true" ]]; then
+    _has_tagged_audit_instance && _PRE_EXISTING_AUDIT_INSTANCE=true
+  fi
+
   # Opt-out: skip Part 2 entirely.
   if [[ "$PROVISION_INSTANCE" == "false" ]]; then
     warn "SCW_INSTANCE_IP is unset and PROVISION_INSTANCE=false — skipping audit trail"
@@ -911,10 +920,6 @@ provision_audit_trail_instance() {
     SCW_INSTANCE_IP="<dry-run-instance-ip>"
     return 0
   fi
-
-  # Mark any tagged Instance (running OR stopped) as pre-existing so end-of-run
-  # cleanup doesn't revoke keys a stopped collector's config still references.
-  _has_tagged_audit_instance && _PRE_EXISTING_AUDIT_INSTANCE=true
 
   # Reuse an existing tagged Instance if present.
   local existing id ip

--- a/scaleway/log_forwarding/setup-logs.sh
+++ b/scaleway/log_forwarding/setup-logs.sh
@@ -875,8 +875,17 @@ _find_audit_instance() {
 # of state.  Broader than _find_audit_instance (which is "running"-only) so the
 # end-of-run key cleanup gate also catches stopped/archived collectors whose
 # config files still reference an old key.
+#
+# Fail-safe on API errors: assume a collector might exist so cleanup preserves
+# its keys.  Calls scw directly (not _list_audit_instances_json) because that
+# helper swallows failures with `|| echo "[]"` — indistinguishable from a
+# legitimate empty result.
 _has_tagged_audit_instance() {
-  [[ "$(_list_audit_instances_json | jq 'length' 2>/dev/null || echo 0)" -gt 0 ]]
+  local output
+  output=$(scw instance server list zone="$SCW_AUDIT_INSTANCE_ZONE" \
+           tags.0="$AUDIT_INSTANCE_TAG" -o json 2>/dev/null) \
+    || return 0
+  [[ "$(jq 'length' <<<"$output" 2>/dev/null || echo 0)" -gt 0 ]]
 }
 
 # Ensure SCW_INSTANCE_IP is set, provisioning a new Instance if it isn't.

--- a/scaleway/log_forwarding/setup-logs.sh
+++ b/scaleway/log_forwarding/setup-logs.sh
@@ -1068,7 +1068,9 @@ setup_audit_trail() {
   # ssh-keyscan it replaces) but defers to the user's ~/.ssh/config for
   # ProxyJump, so private-subnet customers get bastion handling for free
   # via their existing ssh config without needing script-specific env vars.
-  local -a ssh_opts=(-o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o "UserKnownHostsFile=${work_dir}/known_hosts")
+  # Inherit the user's default UserKnownHostsFile so existing pins (target
+  # and bastion) are honored and accepted keys persist across runs.
+  local -a ssh_opts=(-o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new)
 
   log "Verifying SSH access to ${SCW_INSTANCE_IP}..."
   if ! ssh "${ssh_opts[@]}" "${SCW_INSTANCE_USER}@${SCW_INSTANCE_IP}" true 2>/dev/null; then

--- a/scaleway/log_forwarding/setup-logs.sh
+++ b/scaleway/log_forwarding/setup-logs.sh
@@ -105,6 +105,13 @@
 #   SCW_INSTANCE_USER     SSH user for the Instance                    [default: root]
 #   SCW_ACCOUNT_NAME      Name for the Datadog integration account     [default: SCW_PROJECT_ID]
 #
+# For private-subnet audit-trail Instances, configure ProxyJump in
+# ~/.ssh/config so the script's ssh/scp calls tunnel transparently:
+#   Host my-private-vm
+#       HostName <private-ip>
+#       ProxyJump bastion@<gateway-ip>:61000
+# See https://www.scaleway.com/en/docs/public-gateways/how-to/use-ssh-bastion/
+#
 # ─────────────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
@@ -1021,28 +1028,21 @@ setup_audit_trail() {
     || { warn "Failed to create temp dir — skipping audit trail setup"; return 1; }
   trap '[[ -n "${cid:-}" ]] && docker rm -f "$cid" >/dev/null 2>&1 || true; [[ -n "${work_dir:-}" ]] && rm -rf "$work_dir"' RETURN
 
-  # Fetch and pin the instance's host key so we never skip verification.
-  # StrictHostKeyChecking=no would open a MITM window on a script that deploys
-  # credentials to root — we accept the key once here instead.
-  log "Fetching SSH host key from ${SCW_INSTANCE_IP}..."
-  ssh-keyscan -T 10 "$SCW_INSTANCE_IP" > "$work_dir/known_hosts" 2>/dev/null \
-    || {
-      warn "Could not reach ${SCW_INSTANCE_IP} on port 22 — skipping audit trail."
-      warn "  Check that:"
-      warn "    1. The instance is running and SCW_INSTANCE_IP is correct"
-      warn "    2. Port 22 is open in the instance's security group"
-      warn "    3. Your SSH key is registered in Scaleway:"
-      warn "       https://www.scaleway.com/en/docs/organizations-and-projects/how-to/create-ssh-key/"
-      return 1
-    }
-
-  local -a ssh_opts=(-o BatchMode=yes -o ConnectTimeout=10 -o "UserKnownHostsFile=${work_dir}/known_hosts")
+  # accept-new is TOFU on first contact (same security as the explicit
+  # ssh-keyscan it replaces) but defers to the user's ~/.ssh/config for
+  # ProxyJump, so private-subnet customers get bastion handling for free
+  # via their existing ssh config without needing script-specific env vars.
+  local -a ssh_opts=(-o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o "UserKnownHostsFile=${work_dir}/known_hosts")
 
   log "Verifying SSH access to ${SCW_INSTANCE_IP}..."
   if ! ssh "${ssh_opts[@]}" "${SCW_INSTANCE_USER}@${SCW_INSTANCE_IP}" true 2>/dev/null; then
     warn "Cannot reach ${SCW_INSTANCE_USER}@${SCW_INSTANCE_IP} via SSH."
-    warn "Make sure your public SSH key is registered in your Scaleway account and re-run:"
-    warn "  https://www.scaleway.com/en/docs/organizations-and-projects/how-to/create-ssh-key/"
+    warn "Check that:"
+    warn "  1. The instance is running and SCW_INSTANCE_IP is correct"
+    warn "  2. Your SSH key is registered in Scaleway:"
+    warn "     https://www.scaleway.com/en/docs/organizations-and-projects/how-to/create-ssh-key/"
+    warn "  3. If the instance is in a private subnet, configure ProxyJump in ~/.ssh/config:"
+    warn "     https://www.scaleway.com/en/docs/public-gateways/how-to/use-ssh-bastion/"
     return 1
   fi
   ok "SSH access verified"

--- a/scaleway/log_forwarding/setup-logs.sh
+++ b/scaleway/log_forwarding/setup-logs.sh
@@ -313,6 +313,10 @@ IAM_ACCESS_KEY=""
 IAM_SECRET_KEY=""
 _IAM_OLD_KEYS=""
 _AUDIT_DEPLOYED=false
+# True when a collector might already be running with an existing key
+# (tagged Instance from a prior run, or BYO SCW_INSTANCE_IP).  Gates the
+# end-of-run cleanup so we don't revoke a key the live collector still uses.
+_PRE_EXISTING_AUDIT_INSTANCE=false
 # Cockpit Part 1 outcomes — used in main() to decide whether to register the
 # Datadog account.  If nothing worked, we skip Part 3 to avoid leaving a
 # dangling integration entry with no data flowing.
@@ -867,6 +871,14 @@ _find_audit_instance() {
     | head -1
 }
 
+# True if any Instance tagged AUDIT_INSTANCE_TAG exists in this zone, regardless
+# of state.  Broader than _find_audit_instance (which is "running"-only) so the
+# end-of-run key cleanup gate also catches stopped/archived collectors whose
+# config files still reference an old key.
+_has_tagged_audit_instance() {
+  [[ "$(_list_audit_instances_json | jq 'length' 2>/dev/null || echo 0)" -gt 0 ]]
+}
+
 # Ensure SCW_INSTANCE_IP is set, provisioning a new Instance if it isn't.
 # Honors three short-circuit paths before creating anything new:
 #   1. SCW_INSTANCE_IP already set — BYO escape hatch for customers who want
@@ -876,7 +888,11 @@ _find_audit_instance() {
 #      reuse on re-runs of the auto-provisioned default.
 #   3. PROVISION_INSTANCE=false — opt out, skip Part 2 entirely.
 provision_audit_trail_instance() {
-  [[ -n "${SCW_INSTANCE_IP:-}" ]] && return 0
+  if [[ -n "${SCW_INSTANCE_IP:-}" ]]; then
+    # BYO Instance: conservatively assume it might already host a collector.
+    _PRE_EXISTING_AUDIT_INSTANCE=true
+    return 0
+  fi
 
   # Opt-out: skip Part 2 entirely.
   if [[ "$PROVISION_INSTANCE" == "false" ]]; then
@@ -896,6 +912,10 @@ provision_audit_trail_instance() {
     return 0
   fi
 
+  # Mark any tagged Instance (running OR stopped) as pre-existing so end-of-run
+  # cleanup doesn't revoke keys a stopped collector's config still references.
+  _has_tagged_audit_instance && _PRE_EXISTING_AUDIT_INSTANCE=true
+
   # Reuse an existing tagged Instance if present.
   local existing id ip
   existing=$(_find_audit_instance)
@@ -904,9 +924,11 @@ provision_audit_trail_instance() {
     if [[ -n "$ip" && "$ip" != "null" ]]; then
       log "Reusing existing audit-trail Instance ${id} at ${ip}"
       SCW_INSTANCE_IP="$ip"
+      _PRE_EXISTING_AUDIT_INSTANCE=true
       return 0
     fi
     warn "Found existing audit-trail Instance ${id} but it has no public IP — skipping"
+    _PRE_EXISTING_AUDIT_INSTANCE=true
     return 1
   fi
 
@@ -1203,8 +1225,13 @@ main() {
   register_datadog_account
 
   # A deployed audit collector that was not redeployed this run still holds the
-  # old key, so revoking it would break log forwarding.
-  if [[ "$SCW_AUDIT_TRAIL_ENABLED" != "true" ]] || [[ "$_AUDIT_DEPLOYED" == "true" ]]; then
+  # old key, so revoking it would break log forwarding.  But if no prior
+  # collector exists at all (auto-provision path on first/failed attempts),
+  # there's nothing to break — clean up the staged old keys so they don't
+  # accumulate across runs.
+  if [[ "$SCW_AUDIT_TRAIL_ENABLED" != "true" ]] \
+     || [[ "$_AUDIT_DEPLOYED" == "true" ]] \
+     || [[ "$_PRE_EXISTING_AUDIT_INSTANCE" != "true" ]]; then
     # Run the delete with the original (owner-level) creds — the script's
     # current SCW_*_KEY are the app's, which lack IAM write.  Use env-var
     # form so the child `scw` process actually inherits the override.


### PR DESCRIPTION
## Summary

Two related fixes to the Scaleway setup script.

### 1. Clean up rotated IAM keys when no prior collector exists

The end-of-run cleanup is gated on `SCW_AUDIT_TRAIL_ENABLED != true || _AUDIT_DEPLOYED == true`. The intent (preserve old keys if a running collector might still use one) is correct, but the gate is too narrow: when audit trail is enabled but the script has never managed to deploy a collector — typical first-run failures: missing prereqs, unreachable Instance, etc. — there is no collector to break, yet cleanup still skips and old keys pile up across re-runs. We've observed the IAM app accumulate 5 stale keys across a few re-run attempts.

Track `_PRE_EXISTING_AUDIT_INSTANCE` so cleanup knows when it's safe to fire:

| Path | `_PRE_EXISTING_AUDIT_INSTANCE` |
|---|---|
| BYO (`SCW_INSTANCE_IP` set) | `true` — conservatively assume Instance may have a collector |
| Auto-provision, tagged Instance found (any state, running or stopped) | `true` |
| Otherwise (first time, no Instance yet) | `false` |

A stopped tagged Instance still has a `collector.env` referencing the old key on disk; revoking it would break log forwarding the next time the Instance boots. `_has_tagged_audit_instance` broadens the check beyond the running-only `_find_audit_instance` so the gate catches that case.

Widen the cleanup gate:

| Audit toggle | Redeployed this run | Pre-existing Instance | Cleanup runs? |
|---|---|---|---|
| off | — | — | ✓ (unchanged) |
| on | ✓ | — | ✓ (unchanged) |
| on | ✗ | ✗ | **✓ (new)** — no collector to break, safe to clean |
| on | ✗ | ✓ | ✗ (unchanged) — protects the live collector |

### 2. Make SSH work for private-subnet Instances via the user's ssh-config

The audit-trail script's `ssh-keyscan` step fails when the target Instance lives in a private subnet — it isn't reachable directly. Scaleway customers in this situation typically already configure `ProxyJump` in `~/.ssh/config` (Scaleway's own [Public Gateway SSH bastion docs](https://www.scaleway.com/en/docs/public-gateways/how-to/use-ssh-bastion/) teach the pattern); the script should defer to that.

Replace `ssh-keyscan` + the pinned `UserKnownHostsFile` flow with `-o StrictHostKeyChecking=accept-new` on the `ssh_opts`. `accept-new` is TOFU on first contact (same security posture as ssh-keyscan), and ssh applies the user's ssh-config — including `ProxyJump` — to every `ssh`/`scp` call in the script. The "cannot reach Instance" warning now points private-subnet customers at Scaleway's SSH bastion docs.

Customers with a private-subnet Instance add a Host stanza to their `~/.ssh/config`:

```
Host my-private-vm
    HostName <private-ip>
    ProxyJump bastion@<gateway-ip>:61000
```

and run the script with `SCW_INSTANCE_IP=my-private-vm`. SSH handles the rest.

## Test plan

- [x] `bash -n` syntax check clean
- [x] `--dry-run` audit off — completes end-to-end
- [x] `--dry-run` audit on, auto-provision — completes end-to-end
- [x] `--dry-run` audit on, BYO `SCW_INSTANCE_IP` — completes end-to-end
- [x] Manual: private-subnet Instance behind Scaleway Public Gateway SSH bastion + `ProxyJump` in `~/.ssh/config` → `setup_audit_trail` completes end-to-end (SSH verified, OTel collector built, `scp`'d to `/usr/local/bin/otelcol-audit-trail`, `collector.env` deployed with 0600 perms, `systemctl enable` + restart succeed)
- [ ] Manual: re-run with audit enabled but provisioning broken, confirm staged old keys are deleted at end-of-run instead of accumulating

🤖 Generated with [Claude Code](https://claude.com/claude-code)