### PR TITLE
ECI: Set EPM integration user password to client secret during onboarding

### DIFF
--- a/oracle_fusion/integration_quickstart/README.md
+++ b/oracle_fusion/integration_quickstart/README.md
@@ -4,6 +4,12 @@ Automates the full Oracle Fusion + EPM integration user onboarding for Datadog.
 Creates the OCI IAM confidential application, Fusion integration user,
 assigns the required Fusion role, and grants EPM Service Administrator access.
 
+When `--epm-app-id` is provided, the script also sets the integration user's
+IDCS password to the confidential app's client secret. Datadog's EPM crawler
+authenticates to Oracle's EPM REST APIs with HTTP Basic Auth (client_id as
+username, client_secret as password) because Oracle's EPM gateway rejects
+OAuth tokens for these endpoints.
+
 ## Prerequisites
 
 - [OCI CLI](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm) configured with Identity Domain Administrator permissions

--- a/oracle_fusion/integration_quickstart/README.md
+++ b/oracle_fusion/integration_quickstart/README.md
@@ -4,12 +4,6 @@ Automates the full Oracle Fusion + EPM integration user onboarding for Datadog.
 Creates the OCI IAM confidential application, Fusion integration user,
 assigns the required Fusion role, and grants EPM Service Administrator access.
 
-When `--epm-app-id` is provided, the script also sets the integration user's
-IDCS password to the confidential app's client secret. Datadog's EPM crawler
-authenticates to Oracle's EPM REST APIs with HTTP Basic Auth (client_id as
-username, client_secret as password) because Oracle's EPM gateway rejects
-OAuth tokens for these endpoints.
-
 ## Prerequisites
 
 - [OCI CLI](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm) configured with Identity Domain Administrator permissions

--- a/oracle_fusion/integration_quickstart/setup.sh
+++ b/oracle_fusion/integration_quickstart/setup.sh
@@ -993,6 +993,24 @@ except Exception: print('')
     success "Client secret regenerated"
 fi
 
+# Oracle's EPM REST gateway rejects OAuth tokens with a "Token Audience" error
+# that Oracle provides no supported fix for, so the EPM crawler falls back to
+# HTTP Basic Auth using the confidential app's client_id/client_secret. That
+# requires the IDCS user's password to match the client_secret.
+if [[ -n "$EPM_APP_ID" ]]; then
+    info "Setting EPM integration user password (used for Basic Auth fallback)..."
+    oci identity-domains user-password-changer put \
+        --endpoint "$IDENTITY_DOMAIN_URL" \
+        --user-password-changer-id "$OCI_IAM_USER_ID" \
+        --schemas '["urn:ietf:params:scim:schemas:oracle:idcs:UserPasswordChanger"]' \
+        --password "$CLIENT_SECRET" \
+        --output json > /dev/null 2>/dev/null || fatal \
+        "Failed to set password for EPM integration user '${CLIENT_ID}'" \
+        "Ensure your OCI credentials have permission to change user passwords in the identity domain." \
+        "Check: OCI Console → Domains → Administrators"
+    success "EPM integration user password set"
+fi
+
 # Build payload — omit optional fields when values are absent;
 # include client_secret when available (new app); omit when empty (PATCH keeps existing secret).
 payload=$(CLIENT_ID="$CLIENT_ID" TOKEN_URL="$TOKEN_URL" \

--- a/oracle_fusion/integration_quickstart/setup.sh
+++ b/oracle_fusion/integration_quickstart/setup.sh
@@ -1022,7 +1022,7 @@ except Exception:
     resources = []
 policy = next((r for r in resources if 'default' in r.get('name', '').lower()), resources[0] if resources else {})
 
-min_length = int(get(policy, 'minLength', 'min-length', default=8))
+min_length = int(get(policy, 'minLength', 'min-length', default=14))
 max_length = int(get(policy, 'maxLength', 'max-length', default=20))
 min_lower = int(get(policy, 'minLowerCase', 'min-lower-case', default=1))
 min_upper = int(get(policy, 'minUpperCase', 'min-upper-case', default=1))

--- a/oracle_fusion/integration_quickstart/setup.sh
+++ b/oracle_fusion/integration_quickstart/setup.sh
@@ -1006,7 +1006,7 @@ if [[ -n "$EPM_APP_ID" ]]; then
     info "Setting EPM integration user password (used for Basic Auth fallback)..."
     policy_resp=$(oci identity-domains password-policies list \
         --endpoint "$IDENTITY_DOMAIN_URL" \
-        --output json 2>/dev/null)
+        --output json 2>/dev/null) || true
     EPM_TOKEN=$(echo "$policy_resp" | python3 -c "
 import sys, json, secrets, string
 

--- a/oracle_fusion/integration_quickstart/setup.sh
+++ b/oracle_fusion/integration_quickstart/setup.sh
@@ -182,6 +182,7 @@ print(json.dumps(scopes))
 # ── State tracking ────────────────────────────────────────────────────────────
 CLIENT_ID=""
 CLIENT_SECRET=""
+EPM_TOKEN=""
 FUSION_USER_ID=""
 OCI_IAM_USER_ID=""
 
@@ -995,18 +996,32 @@ fi
 
 # Oracle's EPM REST gateway rejects OAuth tokens with a "Token Audience" error
 # that Oracle provides no supported fix for, so the EPM crawler falls back to
-# HTTP Basic Auth using the confidential app's client_id/client_secret. That
-# requires the IDCS user's password to match the client_secret.
+# HTTP Basic Auth using the confidential app's client_id and a dedicated
+# EPM token. The token is generated here (not reused from client_secret)
+# because Oracle's auto-generated client_secret is a fixed length/format that
+# can violate an arbitrary tenant's IDCS password policy.
 if [[ -n "$EPM_APP_ID" ]]; then
     info "Setting EPM integration user password (used for Basic Auth fallback)..."
-    oci identity-domains user-password-changer put \
+    EPM_TOKEN=$(python3 -c "
+import secrets, string
+alphabet = string.ascii_letters + string.digits
+while True:
+    pwd = ''.join(secrets.choice(alphabet) for _ in range(24))
+    if (any(c.isupper() for c in pwd) and any(c.islower() for c in pwd)
+            and any(c.isdigit() for c in pwd)):
+        print(pwd)
+        break
+")
+    _pwd_err=$(oci identity-domains user-password-changer put \
         --endpoint "$IDENTITY_DOMAIN_URL" \
         --user-password-changer-id "$OCI_IAM_USER_ID" \
         --schemas '["urn:ietf:params:scim:schemas:oracle:idcs:UserPasswordChanger"]' \
-        --password "$CLIENT_SECRET" \
+        --password "$EPM_TOKEN" \
         --force \
-        --output json > /dev/null 2>/dev/null || fatal \
+        --output json 2>&1 > /dev/null) && _pwd_status=0 || _pwd_status=$?
+    [[ $_pwd_status -ne 0 ]] && fatal \
         "Failed to set password for EPM integration user '${CLIENT_ID}'" \
+        "$_pwd_err" \
         "Ensure your OCI credentials have permission to change user passwords in the identity domain." \
         "Check: OCI Console → Domains → Administrators"
     success "EPM integration user password set"
@@ -1018,7 +1033,7 @@ payload=$(CLIENT_ID="$CLIENT_ID" TOKEN_URL="$TOKEN_URL" \
     FUSION_SCOPE="${FUSION_SCOPE:-}" EPM_SCOPE="${EPM_SCOPE:-}" \
     FUSION_BASE_URL="${FUSION_BASE_URL:-}" EPM_BASE_URL="${EPM_BASE_URL:-}" \
     FUSION_APP_ID="${FUSION_APP_ID:-}" EPM_APP_ID="${EPM_APP_ID:-}" \
-    ACCOUNT_NAME="$ACCOUNT_NAME" CLIENT_SECRET="${CLIENT_SECRET:-}" python3 -c "
+    ACCOUNT_NAME="$ACCOUNT_NAME" CLIENT_SECRET="${CLIENT_SECRET:-}" EPM_TOKEN="${EPM_TOKEN:-}" python3 -c "
 import json, os
 settings = {
     'client_id': os.environ['CLIENT_ID'],
@@ -1044,7 +1059,11 @@ if enabled:
 settings['version'] = '1.0'
 attrs = {'name': os.environ['ACCOUNT_NAME'], 'settings': settings}
 client_secret = os.environ.get('CLIENT_SECRET', '')
-if client_secret: attrs['secrets'] = {'client_secret': client_secret}
+epm_token = os.environ.get('EPM_TOKEN', '')
+secrets = {}
+if client_secret: secrets['client_secret'] = client_secret
+if epm_token: secrets['epm_token'] = epm_token
+if secrets: attrs['secrets'] = secrets
 print(json.dumps({'data': {'type': 'Account', 'attributes': attrs}}))
 " 2>/dev/null)
 

--- a/oracle_fusion/integration_quickstart/setup.sh
+++ b/oracle_fusion/integration_quickstart/setup.sh
@@ -1027,7 +1027,7 @@ max_length = int(get(policy, 'maxLength', 'max-length', default=20))
 min_lower = int(get(policy, 'minLowerCase', 'min-lower-case', default=1))
 min_upper = int(get(policy, 'minUpperCase', 'min-upper-case', default=1))
 min_numerals = int(get(policy, 'minNumerals', 'min-numerals', default=1))
-min_special = int(get(policy, 'minSpecialChars', 'min-special-chars', default=0))
+min_special = int(get(policy, 'minSpecialChars', 'min-special-chars', default=1))
 
 required = min_lower + min_upper + min_numerals + min_special
 length = max(min_length, min(24, max_length))

--- a/oracle_fusion/integration_quickstart/setup.sh
+++ b/oracle_fusion/integration_quickstart/setup.sh
@@ -999,18 +999,50 @@ fi
 # HTTP Basic Auth using the confidential app's client_id and a dedicated
 # EPM token. The token is generated here (not reused from client_secret)
 # because Oracle's auto-generated client_secret is a fixed length/format that
-# can violate an arbitrary tenant's IDCS password policy.
+# can violate an arbitrary tenant's IDCS password policy. Oracle has no
+# endpoint that generates a policy-compliant password for us, so we fetch the
+# domain's password policy and build a token that satisfies it ourselves.
 if [[ -n "$EPM_APP_ID" ]]; then
     info "Setting EPM integration user password (used for Basic Auth fallback)..."
-    EPM_TOKEN=$(python3 -c "
-import secrets, string
-alphabet = string.ascii_letters + string.digits
-while True:
-    pwd = ''.join(secrets.choice(alphabet) for _ in range(24))
-    if (any(c.isupper() for c in pwd) and any(c.islower() for c in pwd)
-            and any(c.isdigit() for c in pwd)):
-        print(pwd)
-        break
+    policy_resp=$(oci identity-domains password-policies list \
+        --endpoint "$IDENTITY_DOMAIN_URL" \
+        --output json 2>/dev/null)
+    EPM_TOKEN=$(echo "$policy_resp" | python3 -c "
+import sys, json, secrets, string
+
+def get(policy, *names, default=None):
+    for name in names:
+        if name in policy:
+            return policy[name]
+    return default
+
+try:
+    resources = json.load(sys.stdin).get('data', {}).get('resources', [])
+except Exception:
+    resources = []
+policy = next((r for r in resources if 'default' in r.get('name', '').lower()), resources[0] if resources else {})
+
+min_length = int(get(policy, 'minLength', 'min-length', default=8))
+max_length = int(get(policy, 'maxLength', 'max-length', default=40))
+min_lower = int(get(policy, 'minLowerCase', 'min-lower-case', default=1))
+min_upper = int(get(policy, 'minUpperCase', 'min-upper-case', default=1))
+min_numerals = int(get(policy, 'minNumerals', 'min-numerals', default=1))
+min_special = int(get(policy, 'minSpecialChars', 'min-special-chars', default=0))
+
+required = min_lower + min_upper + min_numerals + min_special
+length = max(min_length, min(24, max_length))
+length = max(length, required)
+length = min(length, max_length)
+
+lower, upper, digits, special = string.ascii_lowercase, string.ascii_uppercase, string.digits, '!@#$%^*_-+='
+chars = ([secrets.choice(lower) for _ in range(min_lower)]
+         + [secrets.choice(upper) for _ in range(min_upper)]
+         + [secrets.choice(digits) for _ in range(min_numerals)]
+         + [secrets.choice(special) for _ in range(min_special)])
+pool = lower + upper + digits + (special if min_special else '')
+chars += [secrets.choice(pool) for _ in range(length - len(chars))]
+secrets.SystemRandom().shuffle(chars)
+print(''.join(chars))
 ")
     _pwd_err=$(oci identity-domains user-password-changer put \
         --endpoint "$IDENTITY_DOMAIN_URL" \

--- a/oracle_fusion/integration_quickstart/setup.sh
+++ b/oracle_fusion/integration_quickstart/setup.sh
@@ -1023,7 +1023,7 @@ except Exception:
 policy = next((r for r in resources if 'default' in r.get('name', '').lower()), resources[0] if resources else {})
 
 min_length = int(get(policy, 'minLength', 'min-length', default=8))
-max_length = int(get(policy, 'maxLength', 'max-length', default=40))
+max_length = int(get(policy, 'maxLength', 'max-length', default=20))
 min_lower = int(get(policy, 'minLowerCase', 'min-lower-case', default=1))
 min_upper = int(get(policy, 'minUpperCase', 'min-upper-case', default=1))
 min_numerals = int(get(policy, 'minNumerals', 'min-numerals', default=1))

--- a/oracle_fusion/integration_quickstart/setup.sh
+++ b/oracle_fusion/integration_quickstart/setup.sh
@@ -1012,7 +1012,7 @@ import sys, json, secrets, string
 
 def get(policy, *names, default=None):
     for name in names:
-        if name in policy:
+        if policy.get(name) is not None:
             return policy[name]
     return default
 

--- a/oracle_fusion/integration_quickstart/setup.sh
+++ b/oracle_fusion/integration_quickstart/setup.sh
@@ -1004,6 +1004,7 @@ if [[ -n "$EPM_APP_ID" ]]; then
         --user-password-changer-id "$OCI_IAM_USER_ID" \
         --schemas '["urn:ietf:params:scim:schemas:oracle:idcs:UserPasswordChanger"]' \
         --password "$CLIENT_SECRET" \
+        --force \
         --output json > /dev/null 2>/dev/null || fatal \
         "Failed to set password for EPM integration user '${CLIENT_ID}'" \
         "Ensure your OCI credentials have permission to change user passwords in the identity domain." \

--- a/oracle_fusion/integration_quickstart/setup.sh
+++ b/oracle_fusion/integration_quickstart/setup.sh
@@ -1086,4 +1086,10 @@ if [[ -n "${EPM_BASE_URL:-}" ]]; then
     echo -e "  Datadog Integration user is present. Otherwise, EPM does not sync the user"
     echo -e "  automatically until the next automatic refresh."
     echo ""
+    echo -e "  ${YELLOW}${BOLD}Note:${NC} Add your EPM base URL as a secondary audience so EPM accepts the"
+    echo -e "  confidential app's tokens. In the OCI Console, go to Domains → Oracle Cloud Services →"
+    echo -e "  <Your EPM Instance> → OAuth Configuration, and paste '${EPM_BASE_URL}' as a secondary audience."
+    echo -e "  Until this is done, Datadog will default to HTTP Basic Auth through the provisioned"
+    echo -e "  integration user for EPM monitoring."
+    echo ""
 fi


### PR DESCRIPTION
## What
Updates the Oracle Fusion + EPM integration quickstart script (`oracle_fusion/integration_quickstart/setup.sh`) to set the confidential app's client secret as the created IDCS integration user's password whenever `--epm-app-id` is provided.

## Why
Oracle's EPM REST gateway rejects OAuth tokens with a "Token Audience" error that Oracle provides no supported client-side fix for. Datadog's ECI EPM log crawlers (see companion dd-source PR) now fall back to HTTP Basic Auth against these endpoints, using the OAuth client_id as username and client_secret as password. That requires the underlying IDCS user to actually have a password set matching the client_secret — this script is the only place that user gets created/onboarded, so it needs to set it.

## Testing
- `bash -n oracle_fusion/integration_quickstart/setup.sh` (syntax check)
- Manually reviewed the new `oci identity-domains user-password-changer put` invocation against `oci identity-domains user-password-changer put --help` to confirm required flags (`--user-password-changer-id`, `--schemas`, `--password`)
- Confirmed `OCI_IAM_USER_ID` and `CLIENT_SECRET` are both guaranteed populated by the point this step runs, for both the EPM-only and Fusion+EPM onboarding paths