### PR TITLE
ECI: Note identity domain requirement for EPM secondary audience config

### DIFF
--- a/oracle_fusion/integration_quickstart/setup.sh
+++ b/oracle_fusion/integration_quickstart/setup.sh
@@ -1141,6 +1141,8 @@ if [[ -n "${EPM_BASE_URL:-}" ]]; then
     echo -e "  ${YELLOW}${BOLD}Note:${NC} Add your EPM base URL as a secondary audience so EPM accepts the"
     echo -e "  confidential app's tokens. In the OCI Console, go to Domains → Oracle Cloud Services →"
     echo -e "  <Your EPM Instance> → OAuth Configuration, and paste '${EPM_BASE_URL}' as a secondary audience."
+    echo -e "  This can only be done while signed in as a user of the identity domain that the EPM"
+    echo -e "  instance resides in."
     echo -e "  Until this is done, Datadog will default to HTTP Basic Auth through the provisioned"
     echo -e "  integration user for EPM monitoring."
     echo ""


### PR DESCRIPTION
## What
Adds a clarifying line to the Oracle Fusion onboarding script's post-setup instructions: configuring the EPM secondary audience can only be done while signed in as a user of the identity domain that the EPM instance resides in.

## Why
No associated ticket. Users following the onboarding output could otherwise attempt this step while signed in as a user from a different identity domain and be confused when it's not possible.

## Testing
`bash -n` syntax check on setup.sh (script has no automated tests). Manually verified the new lines render correctly alongside the surrounding echo statements.