### PR TITLE
Add UK1 site support to Azure logging install

### DIFF
--- a/azure/logging_install/bicep/createUiDefinition.json
+++ b/azure/logging_install/bicep/createUiDefinition.json
@@ -148,6 +148,10 @@
                       "value": "ap2.datadoghq.com"
                     },
                     {
+                      "label": "UK1",
+                      "value": "uk1.datadoghq.com"
+                    },
+                    {
                       "label": "US1-FED",
                       "value": "ddog-gov.com"
                     }

--- a/azure/logging_install/bicep/forwarder.bicep
+++ b/azure/logging_install/bicep/forwarder.bicep
@@ -45,6 +45,7 @@ param datadogApiKey string
   'datadoghq.eu'
   'ap1.datadoghq.com'
   'ap2.datadoghq.com'
+  'uk1.datadoghq.com'
   'us3.datadoghq.com'
   'us5.datadoghq.com'
   'ddog-gov.com'

--- a/azure/logging_install/dist/createUiDefinition.json
+++ b/azure/logging_install/dist/createUiDefinition.json
@@ -148,6 +148,10 @@
                       "value": "ap2.datadoghq.com"
                     },
                     {
+                      "label": "UK1",
+                      "value": "uk1.datadoghq.com"
+                    },
+                    {
                       "label": "US1-FED",
                       "value": "ddog-gov.com"
                     }

--- a/azure/logging_install/dist/forwarder.json
+++ b/azure/logging_install/dist/forwarder.json
@@ -77,6 +77,7 @@
         "datadoghq.eu",
         "ap1.datadoghq.com",
         "ap2.datadoghq.com",
+        "uk1.datadoghq.com",
         "us3.datadoghq.com",
         "us5.datadoghq.com",
         "ddog-gov.com"

--- a/azure/logging_install/src/azure_logging_install/main.py
+++ b/azure/logging_install/src/azure_logging_install/main.py
@@ -66,6 +66,7 @@ def parse_arguments():
             "datadoghq.eu",
             "ap1.datadoghq.com",
             "ap2.datadoghq.com",
+            "uk1.datadoghq.com",
             "us3.datadoghq.com",
             "us5.datadoghq.com",
             "ddog-gov.com",


### PR DESCRIPTION
## Summary
- Add `uk1.datadoghq.com` to the Datadog site dropdown in the Azure Portal UI definition (`createUiDefinition.json`)
- Add `uk1.datadoghq.com` to the `@allowed` constraint in `forwarder.bicep`
- Add `uk1.datadoghq.com` to the argparse choices in the Python CLI (`main.py`)
- Update generated dist artifacts (`dist/createUiDefinition.json`, `dist/forwarder.json`) to match

## Test plan
- [ ] Verify the Azure Portal UI dropdown shows UK1 as a selectable site
- [ ] Verify `az deployment` with `datadogSite=uk1.datadoghq.com` is accepted by the Bicep template
- [ ] Verify `python main.py --datadog-site uk1.datadoghq.com` is accepted by the CLI
- [ ] Confirm forwarder container receives `DD_SITE=uk1.datadoghq.com` and connects successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)